### PR TITLE
mem.c: avoid out of bounds array access in mem bar drawing routine

### DIFF
--- a/platform/EOSRP.160/Makefile.platform.default
+++ b/platform/EOSRP.160/Makefile.platform.default
@@ -9,7 +9,7 @@ ROMBASEADDR     = 0xE0040000
 #          ("meminfo -m" in drysh)    ("memmap" in drysh)
 # Default: 0x000dc878 - 0x001f0ec0, 0x000dc870 - 0x001f1190 (total size 0x114920)
 # Patched: 0x000dc878 - 0x001b0ec0, 0x000dc870 - 0x001b1190 (256K reserved for ML)
-RESTARTSTART    = 0x0017c1f0
+RESTARTSTART = 0x0017c600
 
 # Cortex A9, binaries loaded as Thumb
 CFLAG_USER = -mthumb -mlong-calls

--- a/src/mem.c
+++ b/src/mem.c
@@ -1058,8 +1058,9 @@ static void guess_free_mem_task(void *priv, int delta)
 	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_GREEN1, width);
 	else {
-          uart_printf("[ML] guess_free_mem_task: green: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
-			  sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+          uart_printf("[ML] guess_free_mem_task: green: attempt to write out of bounds on "
+                      "memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
+                      sizeof(memory_map), start, width, chunkAddress, chunkAvail);
 	}
 
         currentChunk = GetNextMemoryChunk(shoot_suite, currentChunk);
@@ -1098,8 +1099,9 @@ static void guess_free_mem_task(void *priv, int delta)
 	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_CYAN, width);
 	else {
-          uart_printf("[ML] guess_free_mem_task: cyan: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
-			  sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+          uart_printf("[ML] guess_free_mem_task: cyan: attempt to write out of bounds on "
+                      "memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
+                      sizeof(memory_map), start, width, chunkAddress, chunkAvail);
 	}
 
         currentChunk = GetNextMemoryChunk(srm_suite, currentChunk);

--- a/src/mem.c
+++ b/src/mem.c
@@ -103,6 +103,7 @@ struct mem_allocator
 /* Canon stubs */
 extern int GetMemoryInformation(int* total, int* free);
 extern int GetSizeOfMaxRegion(int* max_region);
+extern int uart_printf(const char* fmt, ...);
 
 int GetFreeMemForAllocateMemory()
 {
@@ -1053,7 +1054,13 @@ static void guess_free_mem_task(void *priv, int delta)
 
         int start = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAddress);
         int width = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAvail);
-        memset(memory_map + start, COLOR_GREEN1, width);
+
+	if ((start < 720) && (start + width < 720))
+          memset(memory_map + start, COLOR_GREEN1, width);
+	else {
+          uart_printf("[ML] guess_free_mem_task: green: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
+			  sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+	}
 
         currentChunk = GetNextMemoryChunk(shoot_suite, currentChunk);
     }
@@ -1087,7 +1094,13 @@ static void guess_free_mem_task(void *priv, int delta)
 
         int start = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAddress);
         int width = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAvail);
-        memset(memory_map + start, COLOR_CYAN, width);
+
+	if ((start < 720) && (start + width < 720))
+          memset(memory_map + start, COLOR_CYAN, width);
+	else {
+          uart_printf("[ML] guess_free_mem_task: cyan: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
+			  sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+	}
 
         currentChunk = GetNextMemoryChunk(srm_suite, currentChunk);
     }

--- a/src/mem.c
+++ b/src/mem.c
@@ -1055,7 +1055,7 @@ static void guess_free_mem_task(void *priv, int delta)
         int start = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAddress);
         int width = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAvail);
 
-	if ((start < 720) && (start + width < 720))
+	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_GREEN1, width);
 	else {
           uart_printf("[ML] guess_free_mem_task: green: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
@@ -1095,7 +1095,7 @@ static void guess_free_mem_task(void *priv, int delta)
         int start = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAddress);
         int width = MEMORY_MAP_ADDRESS_TO_INDEX(chunkAvail);
 
-	if ((start < 720) && (start + width < 720))
+	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_CYAN, width);
 	else {
           uart_printf("[ML] guess_free_mem_task: cyan: attempt to write out of bounds on memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",

--- a/src/mem.c
+++ b/src/mem.c
@@ -103,7 +103,6 @@ struct mem_allocator
 /* Canon stubs */
 extern int GetMemoryInformation(int* total, int* free);
 extern int GetSizeOfMaxRegion(int* max_region);
-extern int uart_printf(const char* fmt, ...);
 
 int GetFreeMemForAllocateMemory()
 {
@@ -1058,9 +1057,8 @@ static void guess_free_mem_task(void *priv, int delta)
 	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_GREEN1, width);
 	else {
-          uart_printf("[ML] guess_free_mem_task: green: attempt to write out of bounds on "
-                      "memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
-                      sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+          DryosDebugMsg(0, 15, "[ML] g_f_m_t: green: OOB write memory_map[%d]: ", sizeof(memory_map));
+          DryosDebugMsg(0, 15, "[ML] g_f_m_t: s=%d, w=%d, cAd=%X, cAv=%X", start, width, chunkAddress, chunkAvail);
 	}
 
         currentChunk = GetNextMemoryChunk(shoot_suite, currentChunk);
@@ -1099,9 +1097,8 @@ static void guess_free_mem_task(void *priv, int delta)
 	if ((start < sizeof(memory_map)) && (start + width < sizeof(memory_map)))
           memset(memory_map + start, COLOR_CYAN, width);
 	else {
-          uart_printf("[ML] guess_free_mem_task: cyan: attempt to write out of bounds on "
-                      "memory_map[%d]: start=%d, width=%d, chunkAddress=%X, chunkAvail=%X",
-                      sizeof(memory_map), start, width, chunkAddress, chunkAvail);
+          DryosDebugMsg(0, 15, "[ML] g_f_m_t: cyan: OOB write memory_map[%d]: ", sizeof(memory_map));
+          DryosDebugMsg(0, 15, "[ML] g_f_m_t: s=%d, w=%d, cAd=%X, cAv=%X", start, width, chunkAddress, chunkAvail);
 	}
 
         currentChunk = GetNextMemoryChunk(srm_suite, currentChunk);


### PR DESCRIPTION
avoids a crash on D8 cams (or probably all cams with lots of RAM) which happens by a out of bounds array write access when drawing a graphical representation of available and used memory when free mem dialog is opened.