### PR TITLE
A ton of D678 updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ platform/*.OLD
 platform/*/qemu-helper
 platform/*/version.c
 platform/*/xor_chk
+platform/*/zip
 platform/all/autoexec-all
 platform/all/autoexec-fir
 platform/all/ML

--- a/platform/200D.101/property_whitelist.h
+++ b/platform/200D.101/property_whitelist.h
@@ -34,8 +34,7 @@ const uint32_t prop_handler_deny[] =
 // allow writes / allow prop_request_change() for these:
 const uint32_t prop_write_allow [] =
 {
-    PROP_ICU_AUTO_POWEROFF,
-    PROP_LV_LENS
+    PROP_ICU_AUTO_POWEROFF
 };
 
 // anything not listed above will allow reads but not writes

--- a/platform/200D.101/stubs.S
+++ b/platform/200D.101/stubs.S
@@ -202,9 +202,18 @@ THUMB_FN(0xdf00b615,  msg_queue_create) // CreateMessageQueue - In 50D, msg_queu
 THUMB_FN(0xe04bba45,  prop_deliver)
 //THUMB_FN(0xe04bbde1,  prop_register_slave) // called by"GUI_RegisterPropertySlave"
 THUMB_FN(0xe04bb4df,  prop_register_slave) // "pRegisterSlave"
+
 THUMB_FN(0xe0381ba9,  LiveViewApp_handler) // DebugMsg: "StartLiveViewApp(%#x)", address passed to CreateDialogBox
-THUMB_FN(0xe06cda95,  LiveViewShutterApp_handler) // DebugMsg: "StartLiveViewShutterApp CreateDialogBox(%d)", address passed to CreateDialogBox
+//THUMB_FN(0xe06cda95,  LiveViewShutterApp_handler) // DebugMsg: "StartLiveViewShutterApp CreateDialogBox(%d)", address passed to CreateDialogBox
 THUMB_FN(0xe046fc49,  PlayMain_handler) // DebugMsg: "StartPlayMain", address passed to CreateDialogBox
+
+// See R180 stubs.s for details.
+//DATA_PTR(    0xec7c,  PlayMain_dialog)                    // in StartPlayMain()
+//DATA_PTR(   0x1af3c,  ShootOlcApp_dialog)                 // in StartShootOlcApp()
+DATA_PTR(      0xeb44,  LiveViewApp_dialog)                 // in StartLiveViewApp()
+//DATA_PTR(   0x1a970,  LiveViewShutterApp_dialog)          // in StartLiveViewShutterApp(), not sure if needed
+//DATA_PTR(   0x1be20,  PlayMovieGuideApp_dialog)           // in StartPlayMovieGuideApp()
+
 THUMB_FN(0xe03536c1,  GetCFnData) // "GetCFnData" Function sig is different but the body looks similar.
                                   // Looks like the inner functions use registers the outer doesn't, which confuses Ghidra
                                   // re how many args outer takes.

--- a/platform/5D2.212/consts.h
+++ b/platform/5D2.212/consts.h
@@ -53,6 +53,7 @@
 #define HALFSHUTTER_PRESSED (*(int*)0x1c10)
 
 
+#define LV_OVERLAYS_MODE MEM(0x34894 + 0x48)
 
 #define LV_BOTTOM_BAR_DISPLAYED (((*(int*)0x79B8) == 0xF))
 #define ISO_ADJUSTMENT_ACTIVE ((*(int*)0x79B8) == 0xF) // dec ptpNotifyOlcInfoChanged and look for: if arg1 == 1: MEM(0x79B8) = *(arg2)

--- a/platform/750D.110/consts.h
+++ b/platform/750D.110/consts.h
@@ -49,14 +49,25 @@
 
 #define CURRENT_GUI_MODE (*(int*)0x27394)                 // from SetGUIRequestMode
 
-#define GUIMODE_PLAY 2
-#define GUIMODE_MENU 3
+/**
+ * Some GUI modes as dumped on camera
+ * 0x01 - Play mode
+ * 0x02 - Main menu
+ * 0x2F - LV "Q" menu overlay
+ * Note that overlays below timeout quickly, so they are bad for ML menu.
+ * 0x5B - LV "Shutter speed" overlay
+ * 0x5C - LV "Aperture" overlay
+ * 0x5D - LV "Exposure compensation" overlay
+ * 0x5E - LV "ISO" overlay
+ */
+#define GUIMODE_PLAY 1
+#define GUIMODE_MENU 2
 
 // In bindGUIEventFromGUICBR, look for "LV Set" => arg0 = 8
 // Next, in SetGUIRequestMode, look at what code calls NotifyGUIEvent(8, something)
 // skip RECORDING variant for now
-#define GUIMODE_ML_MENU (lv ? 86 : GUIMODE_MENU)
-//#define GUIMODE_ML_MENU (RECORDING ? 0 : lv ? 86 : GUIMODE_MENU)
+#define GUIMODE_ML_MENU (lv ? 0x5B : GUIMODE_MENU)
+//#define GUIMODE_ML_MENU (RECORDING ? 0 : lv ? 0x5B : GUIMODE_MENU)
 
 // I can't find any official data. Unofficial say 100k
 #define CANON_SHUTTER_RATING 100000

--- a/platform/750D.110/property_whitelist.h
+++ b/platform/750D.110/property_whitelist.h
@@ -34,8 +34,7 @@ const uint32_t prop_handler_deny[] =
 // allow writes / allow prop_request_change() for these:
 const uint32_t prop_write_allow[] =
 {
-    PROP_ICU_AUTO_POWEROFF,
-    PROP_LV_LENS
+    PROP_ICU_AUTO_POWEROFF
 };
 
 // anything not listed above will allow reads but not writes

--- a/platform/750D.110/stubs.S
+++ b/platform/750D.110/stubs.S
@@ -214,5 +214,12 @@ DATA_PTR(       0x0,  LCD_Palette)                          // D6 has no indexed
 THUMB_FN(0xfe410e0a,  PlayMain_handler)                     // msg: "StartPlayMain"
 THUMB_FN(0xfe575c58,  ShootOlcApp_handler)                  // msg: "StartShootOlcApp PushPalette(%d)"
 THUMB_FN(0xfe3d5ecc,  LiveViewApp_handler)                  // msg: "StartLiveViewApp(%#x)"
-THUMB_FN(0xfe69c5d0,  LiveViewShutterApp_handler)           // msg: "LiveViewShutterApp"
+//THUMB_FN(0xfe69c5d0,  LiveViewShutterApp_handler)         // msg: "LiveViewShutterApp"
 THUMB_FN(0xfe31022e,  PlayMovieGuideApp_handler)            // msg: "StartPlayMovieGuideApp"
+
+// See R180 stubs.s for details.
+//DATA_PTR( 0x2BD60,  PlayMain_dialog)                      // in StartPlayMain(), 0x2bd54 + 0xc
+//DATA_PTR( 0x35298,  ShootOlcApp_dialog)                   // in StartShootOlcApp()
+DATA_PTR(   0x2fe98,  LiveViewApp_dialog)                   // in StartLiveViewApp()
+//DATA_PTR( 0x35a58,  LiveViewShutterApp_dialog)            // in StartLiveViewShutterApp(), not sure if needed
+//DATA_PTR( 0x3042c,  PlayMovieGuideApp_dialog)             // in StartPlayMovieGuideApp()

--- a/platform/EOSM.202/consts.h
+++ b/platform/EOSM.202/consts.h
@@ -186,7 +186,7 @@
 #define FRAME_SHUTTER_BLANKING_NOZOOM (*(uint16_t*)0x40481B24) // ADTG register 8061
 #define FRAME_SHUTTER_BLANKING_READ   (lv_dispsize > 1 ? FRAME_SHUTTER_BLANKING_NOZOOM : FRAME_SHUTTER_BLANKING_ZOOM) /* when reading, use the other mode, as it contains the original value (not overriden) */
 //~ #define FRAME_SHUTTER_BLANKING_WRITE  (lv_dispsize > 1 ? &FRAME_SHUTTER_BLANKING_ZOOM : &FRAME_SHUTTER_BLANKING_NOZOOM)
-#define LV_DISP_MODE (MEM(0x89BAC + 0x7C) != 3)
+#define LV_OVERLAYS_MODE MEM(0x89BAC + 0x7C)
 
 // see "Malloc Information"
 #define MALLOC_STRUCT 0x668C8

--- a/platform/EOSRP.160/consts.h
+++ b/platform/EOSRP.160/consts.h
@@ -146,6 +146,14 @@ extern int _WINSYS_BMP_DIRTY_BIT_NEG;
 #define GUIMODE_FLASH_AE 0x22
 #define GUIMODE_PICQ 6
 
+/*
+ * kitor: DIGIC 8 has no PROP_LV_OUTPUT_TYPE (PROP_HOUTPUT_TYPE in ML source)
+ * I looked around LiveViewApp and found `LvInfoToggle_Update()` which updates
+ * variable to represent currently display overlays. Look at R conts.h for more
+ * details.
+ */
+#define LV_OVERLAYS_MODE MEM(0x14cd4)
+
 // all these MVR ones are junk, don't try and record video and they probably don't get used?
 #define MVR_190_STRUCT (*(void**)0) // MVR_190_STRUCT (*(void**)0x1ed8) // look in MVR_Initialize for AllocateMemory call;
                                          // decompile it and see where ret_AllocateMemory is stored.
@@ -164,4 +172,3 @@ extern int _WINSYS_BMP_DIRTY_BIT_NEG;
 #define MVR_BYTES_WRITTEN MEM((212 + MVR_190_STRUCT))
 
 #define LV_BOTTOM_BAR_DISPLAYED 0x0 // wrong, fake bool
-

--- a/platform/EOSRP.160/features.h
+++ b/platform/EOSRP.160/features.h
@@ -1,4 +1,12 @@
 #define FEATURE_VRAM_RGBA
+
+//enable XCM only in full build
+#ifndef ML_MINIMAL_OBJ
+#define CONFIG_COMPOSITOR_XCM
+// DEDICATED_LAYER not yet implemented
+//#define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#endif
+
 #define FEATURE_SHOW_SHUTTER_COUNT
 #define FEATURE_SHOW_TOTAL_SHOTS
 
@@ -7,4 +15,3 @@
 #undef CONFIG_TSKMON
 #undef CONFIG_PROP_REQUEST_CHANGE
 #undef CONFIG_AUTOBACKUP_ROM
-

--- a/platform/EOSRP.160/stubs.S
+++ b/platform/EOSRP.160/stubs.S
@@ -185,9 +185,41 @@ THUMB_FN(0xe00e3ab0,  task_trampoline)    // see comment below:
  */
 THUMB_FN(0xe03c9114, _get_task_info_by_id) // called from function using "StackDump" string
 
-/** General FEATURE_VRAM_RGBA stubs **/
+/**
+ * RGBA / Compositor functions and structures
+ */
+
+/**
+ * Things needed for CONFIG_COMPOSITOR_XCM.
+ *
+ * RP uses two layers (GUI, focus overlays). WINSYS code swaps pointer in
+ * WINSYS structure (one we know as _rgb_vram_info) to select which layer to
+ * draw.
+ *
+ * With FEATURE_COMPOSITOR_XCM we ask XCM via XCM_GetSourceSurface to give us
+ * pointer to layer 0, which is more reliable.
+ */
+THUMB_FN(0xe010efa4, XCM_GetSourceSurface)          // by debug message
+//THUMB_FN(0xe010ed6c, XCM_MakeContext)             // by debug message. Not used in code, left for reference below.
+DATA_PTR(    0xFF78, _pXCM);                        // param1 to XCM_MakeContext() when called from refreshVrmsSurface()
+
+/**
+ * Stubs needed for CONFIG_XCM_DEDICATED_LAYER
+ */
+THUMB_FN(0xe0254b0c, refreshVrmsSurface);           // by debug message.
+DATA_PTR(    0xFF74, display_refresh_needed)        // Easy to spot in refreshVrmsSurface()
+
+/**
+ * General FEATURE_VRAM_RGBA stubs
+ *
+ * _rgb_vram_info is a pointer to first Canon RGBA buffer (GUI).
+ * On RP this is set up by RENDERER_InitializeScreen(), after MARVs are created:
+ * 'rgb_vram_info = RENDERER_LayersArr[0];'
+ */
+//THUMB_FN(0xe0331492, RENDERER_InitializeScreen)   // by debug message. Not used in code, left for reference above.
 THUMB_FN(0xe010c180, XimrExe);                      // In RefreshVrmsSurface, just before "XimrExe" debug message
 DATA_PTR(    0xff60, winsys_sem);                   // Used in RefreshVrmsSurface around XimrExe call
+DATA_PTR(    0xFF1C, _rgb_vram_info);
 
 /** Uncategorized **/
 DATA_PTR(   0x12928,  sd_device)                    // Used as parameter in DryosDebugMsg with "EVICE_POWER_CYCLE bPowerDown=%d" string
@@ -199,9 +231,6 @@ THUMB_FN(0xe06f0358,  _LoadCalendarFromRTC)         // function call after "hand
 THUMB_FN(0xe0596920, _prop_cleanup)                         // function call after "faChangeCBR(ID=%#lx)" string
 THUMB_FN(0xe059638e,  prop_register_slave)                  // function call after "sdsActivate" string
 THUMB_FN(0xe059645c, _prop_request_change)                  // function call after "update inner version string. \"%s\"" string
-
-DATA_PTR(    0xFF1C, _rgb_vram_info); // there is no string string reference nearby by there is a function which returns the 
-                                      // pointer at e03316b0. This function can also be found on other cameras.
 
 // *** CONTINUE HERE! ***
  

--- a/platform/EOSRP.160/stubs.S
+++ b/platform/EOSRP.160/stubs.S
@@ -211,6 +211,13 @@ THUMB_FN(0xe06f3ef8,  ShootOlcApp_handler)                  // contains "DlgOlcM
 THUMB_FN(0xe043519c,  LiveViewApp_handler)                  // contains "DlgLiveView.c During QR Request Event(0x%08X) Consume" string
 THUMB_FN(0xe07e066a,  LiveViewShutterApp_handler)           // msg: "StartLiveViewShutterApp"
 
+// See R180 stubs.s for details.
+//DATA_PTR(   0xe498,  PlayMain_dialog)                    // in PlayMain_StartPlayMain(), 0xe508 - 0x70
+//DATA_PTR(  0x15008,  ShootOlcApp_dialog)                 // in StartShootOlcApp()
+DATA_PTR(    0x14844,  LiveViewApp_dialog)                 // in StartLiveViewApp(), 0x14840 + 0x4
+//DATA_PTR(  0x1e488,  LiveViewShutterApp_dialog)          // in StartLiveViewShutterApp(), not sure if needed
+//DATA_PTR(  0x16338,  PlayMovieGuideApp_dialog)           // in PlayMovieGuide_Start()
+
 /**
  * STUFF BELOW IS WRONG!
  **/

--- a/platform/M50.110/cfn.c
+++ b/platform/M50.110/cfn.c
@@ -1,23 +1,20 @@
 #include <dryos.h>
 #include <property.h>
+#include <cfn-generic.h>
 
-// look on camera menu or review sites to get custom function numbers
+// on M50 these are not CFn, but in main menus
+GENERIC_GET_ALO
+GENERIC_GET_HTP
 
-/* kitor: nerfed everything for now, just in case */
-int get_htp() { return 0; }
-void set_htp(int value) {  return; }
+/* CFn GUI is different than on older generations.
+ * Looks like a generic menu with 5 pages.
+ * GetCFnData(0, <number>) returns proper value*/
 
-int get_alo() { return 0; }
-void set_alo(int value) { return; }
-
-/* kitor: mirrorless, no such option */
+/* mirrorless, no such option */
 int get_mlu() { return 0; }
 void set_mlu(int value) { return; }
 
-/* kitor: not sure what to do? 4-1 opens menu for all button assigments */
+/* kitor: not sure what to do? Leaving nerfed for now.
+ * C.Fn page 5 has all the assigments */
 int cfn_get_af_button_assignment() { return 0; }
 void cfn_set_af_button(int value) { return; }
-
-/* kitor: same as above? */
-int get_af_star_swap() { return 0; }
-void set_af_star_swap(int value) { return; }

--- a/platform/M50.110/consts.h
+++ b/platform/M50.110/consts.h
@@ -85,9 +85,20 @@
 //#define LVAE_ISO_HIS    (*(uint8_t* )(LVAE_STRUCT+0xXX)) // no idea, not referenced in ./src?!
 //#define LVAE_ISO_SPEED  (*(uint8_t* )(LVAE_STRUCT+0xXX))  //WRONG, not sure how to follow
 
+/*
+ * kitor: DIGIC 8 has no PROP_LV_OUTPUT_TYPE (PROP_HOUTPUT_TYPE in ML source)
+ * I looked around LiveViewApp and found `LvInfoToggle_Update()` which updates
+ * variable to represent currently display overlays. Look at R conts.h for more
+ * details.
+ */
+#define LV_OVERLAYS_MODE MEM(0x13CC8)
 
-/* PROPABLY WRONG: Some hacks for early porting */
+/* There's no `DispOperator_PropertyMasterSetDisplayTurnOffOn()` like on EOSR.
+ * PropID 80040083 is also not referenced anywhere.
+ * GUILockTask does DISP_MuteOnOSDLineVram() and DISP_MuteOnOSDPanelVram()
+ * so maybe values stored by those two combined can be used instead. */
 #define DISPLAY_IS_ON               1
+
 /* WRONG! */
 #define HALFSHUTTER_PRESSED         0
 /* kitor: I was unable to find any related stuff from 200D

--- a/platform/M50.110/stubs.S
+++ b/platform/M50.110/stubs.S
@@ -218,10 +218,17 @@ DATA_PTR(       0x0,  LCD_Palette)                          // D8 has no indexed
 THUMB_FN(0xe04c7e5c,  PlayMain_handler)                     // msg: "StartPlayMain"
 THUMB_FN(0xe02d40f2,  ShootOlcApp_handler)                  // msg: "StopShootOlcApp PopPalette(%d)"
 THUMB_FN(0xe04dc446,  LiveViewApp_handler)                  // msg: "StartLiveViewApp(%#x)"
-THUMB_FN(0xe0338a10,  LiveViewShutterApp_handler)           // msg: "StartLiveViewShutterApp"
+//THUMB_FN(0xe0338a10,  LiveViewShutterApp_handler)         // msg: "StartLiveViewShutterApp"
 THUMB_FN(0xe058af54,  PlayMovieGuideApp_handler)            // msg: "StartPlayMovieGuideApp"
 
-THUMB_FN(0xe0337e4c,  LiveViewLevelApp_handler)             // msg: "StartLiveViewLevelApp"
+// See R180 stubs.s for details.
+//DATA_PTR(  0xe708,  PlayMain_dialog)                      // in StartPlayMain()
+//DATA_PTR( 0x13fa4,  ShootOlcApp_dialog)                   // in StartShootOlcApp()
+DATA_PTR(   0x139b8,  LiveViewApp_dialog)                   // in StartLiveViewApp()
+//DATA_PTR( 0x1c434,  LiveViewShutterApp_dialog)            // in StartLiveViewShutterApp(), not sure if needed
+//DATA_PTR( 0x14fa8,  PlayMovieGuideApp_dialog)             // in StartPlayMovieGuideApp()
+
+
 
 /**
  * STUFF BELOW IS WRONG!

--- a/platform/R.180/cfn.c
+++ b/platform/R.180/cfn.c
@@ -1,23 +1,21 @@
 #include <dryos.h>
 #include <property.h>
+#include <cfn-generic.h>
 
-// look on camera menu or review sites to get custom function numbers
+// on R these are not CFn, but in main menus
+GENERIC_GET_ALO
+GENERIC_GET_HTP
 
-/* kitor: nerfed everything for now, just in case */
-int get_htp() { return 0; }
-void set_htp(int value) {  return; }
+/* CFn GUI is different than on older generations.
+ * Looks like a generic menu with C.Fn1-5 tabs (ad C.Fn6 with "clear" option)
+ * GetCFnData(0, <number>) returns proper value*/
 
-int get_alo() { return 0; }
-void set_alo(int value) { return; }
-
-/* kitor: mirrorless, no such option */
+/* mirrorless, no such option */
 int get_mlu() { return 0; }
 void set_mlu(int value) { return; }
 
-/* kitor: not sure what to do? 4-1 opens menu for all button assigments */
+/* kitor: not sure what to do? Leaving nerfed for now.
+ * C.Fn3 has 4 submenusfor wheel directions
+ * C.Fn4 has 3 submenus to adjust buttons, wheels and touchbar */
 int cfn_get_af_button_assignment() { return 0; }
 void cfn_set_af_button(int value) { return; }
-
-/* kitor: same as above? */
-int get_af_star_swap() { return 0; }
-void set_af_star_swap(int value) { return; }

--- a/platform/R.180/consts.h
+++ b/platform/R.180/consts.h
@@ -56,7 +56,7 @@
 // bindGUIEventFromGUICBR DNE on R, however by educated guess from older generations:
 // In SetGUIRequestMode, look at what code calls NotifyGUIEvent(9, something)
 // skip RECORDING variant for now
-#define GUIMODE_ML_MENU (lv ? 0x7F : GUIMODE_MENU)
+#define GUIMODE_ML_MENU (lv ? 0x68 : GUIMODE_MENU)
 //#define GUIMODE_ML_MENU (RECORDING ? 0 : lv ? 0x68 : GUIMODE_MENU)
 
 // I can't find any official data. Unofficial say 200k

--- a/platform/R.180/consts.h
+++ b/platform/R.180/consts.h
@@ -51,6 +51,19 @@
 
 #define CURRENT_GUI_MODE            (*(int*)0x8700)      // see SetGUIRequestMode, Compared with param 1 before write to 0x8708
 
+/**
+ * Some GUI modes as dumped on camera
+ * 0x02 - Play mode
+ * 0x03 - Main menu
+ * 0x29 - Camera mode selection menu
+ * 0x40 - LV "Q" menu overlay
+ * 0x68 - LV "Picture profile" overlay
+ * 0x6E - LV "Shutter speed" overlay
+ * 0x6F - LV "Aperture" overlay
+ * 0x70 - LV "Exposure compensation" overlay
+ * 0x71 - LV "ISO" overlay
+ * 0x7A - LV "Focus mode" overlay
+ */
 #define GUIMODE_PLAY 2
 #define GUIMODE_MENU 3
 // bindGUIEventFromGUICBR DNE on R, however by educated guess from older generations:

--- a/platform/R.180/consts.h
+++ b/platform/R.180/consts.h
@@ -90,6 +90,21 @@
 #define LVAE_MOV_M_CTRL (*(uint8_t* )(LVAE_STRUCT+0x24)) // via "lvae_setmoviemanualcontrol"
 
 /*
+ * kitor: DIGIC 8 has no PROP_LV_OUTPUT_TYPE (PROP_HOUTPUT_TYPE in ML source)
+ * I looked around LiveViewApp and found `LvInfoToggle_Update()` which updates
+ * variable to represent currently display overlays:
+ *    0x0 - 1st overlays mode in LV (top+bottom)
+ *    0x1 - above + sides
+ *    0x2 - above + level
+ *    0x3 - clean overlays
+ *    0x6 - OlcApp? The screen like outside LV on DSLR
+ * Now the fun part - 5D2 and EOSM already use this exact variable! So let's
+ * re-use the existing logic.
+ * It could be backported to older models, 5D3 & 750d refer to it as LvInfoType`
+ */
+#define LV_OVERLAYS_MODE MEM(0x13cf4)
+
+/*
  * kitor: ISO related stuff is not in LVAE struct anymore?
  * iso-related stuff calls 0x02275de which returns pointer at 0x02276168 to 0x6b818
  */

--- a/platform/R.180/features.h
+++ b/platform/R.180/features.h
@@ -1,8 +1,9 @@
 #define FEATURE_VRAM_RGBA
 
-//enable FEATURE_COMPOSITOR_XCM only in full build
+//enable XCM only in full build
 #ifndef ML_MINIMAL_OBJ
-#define FEATURE_COMPOSITOR_XCM
+#define CONFIG_COMPOSITOR_XCM
+#define CONFIG_COMPOSITOR_DEDICATED_LAYER
 #endif
 
 // Don't Click Me menu looks to be intended as a place

--- a/platform/R.180/gui.h
+++ b/platform/R.180/gui.h
@@ -1,62 +1,53 @@
 #ifndef _cameraspecific_gui_h_
 #define _cameraspecific_gui_h_
 
-/* Codes found for R180 */
-
-#define BGMT_PRESS_UP                0x31
-#define BGMT_PRESS_LEFT              0x2F
-#define BGMT_PRESS_RIGHT             0x2D
-#define BGMT_PRESS_DOWN              0x33
-
-/* Q/Set is one button on R */
-#define BGMT_PRESS_SET               0x04
-#define BGMT_UNPRESS_SET             0x05
-
-#define BGMT_TRASH                   0x0E
-#define BGMT_MENU                    0x06
-#define BGMT_INFO                    0x08
-
-#define BGMT_PLAY                    0x0C
+/* As in R180 */
 
 #define BGMT_WHEEL_LEFT              0x02
 #define BGMT_WHEEL_RIGHT             0x03
 
+/* Q/Set is one button on R, but emits SET codes
+ * thus can't use BGMT_Q_SET
+ * Side effect: Submenus shows Q for back,
+ * but BGMT_PLAY needs to be used instead. */
+#define BGMT_PRESS_SET               0x04
+#define BGMT_UNPRESS_SET             0x05
+#define BGMT_MENU                    0x06
+
+#define BGMT_INFO                    0x08
+
+#define BGMT_PLAY                    0x0C
+#define BGMT_TRASH                   0x0E
+
+#define BGMT_PRESS_RIGHT             0x2D
+#define BGMT_UNPRESS_RIGHT           0x2E
+#define BGMT_PRESS_LEFT              0x2F
+#define BGMT_UNPRESS_LEFT            0x30
+#define BGMT_PRESS_UP                0x31
+#define BGMT_UNPRESS_UP              0x32
+#define BGMT_PRESS_DOWN              0x33
+#define BGMT_UNPRESS_DOWN            0x34
+
+/*
+ * Top dial fires 0x02 + 0x9D for left and 0x03 + 0x9D events for right.
+ * Mode dial and RF ring fires only 0x9D, so it is impossible to use for now.
+ *
+ * However we can bind useless touchbar swipes to this function. And it works
+ * without that stupid delay it usually have!
+ */
+#define BGMT_WHEEL_DOWN              0x55 // swipe right
+#define BGMT_WHEEL_UP                0x56 // swipe left
+
 #define BGMT_PRESS_HALFSHUTTER       0x7D
 
-/* WRONG: DNE in R */
-#define BGMT_PRESS_UP_RIGHT          0xF0
-#define BGMT_PRESS_UP_LEFT           0xF1
-#define BGMT_PRESS_DOWN_RIGHT        0xF2
-#define BGMT_PRESS_DOWN_LEFT         0xF3
+// needed for correct shutdown from powersave modes
+#define GMT_GUICMD_LOCK_OFF          0x8E // GUICMD_LOCK_OFF
+#define GMT_GUICMD_OPEN_SLOT_COVER   0x90 // GUICMD_OPEN_SLOT_COVER
+#define GMT_GUICMD_START_AS_CHECK    0x95 // GUICMD_START_AS_CHECK
 
-#define BGMT_JOY_CENTER              0xF4
-/*
- * kitor: Top dial fires 0x02 + 0x9D for left
- *        and 0x03 + 0x9D events for right.
- *        Mode dial fires only 0x9D in both directions
- *        Thus skipping for now.
- *        Same applies for RF lenses ring btw.
- */
-#define BGMT_WHEEL_UP                0xF5
-#define BGMT_WHEEL_DOWN              0xF6
-#define BGMT_LV                      0xF7
-/* what is that ?! */
-#define BGMT_UNPRESS_UDLR            0xF8
+#define GMT_OLC_INFO_CHANGED         0x9D // copyOlcDataToStorage uiCommand(%d)
 
-#define BGMT_PRESS_ZOOM_IN           0xF9
-#define BGMT_UNPRESS_ZOOM_IN         0xE0
-#define BGMT_PRESS_ZOOM_OUT          0xE1
-#define BGMT_UNPRESS_ZOOM_OUT        0xE2
-#define BGMT_PICSTYLE                0xE3
-
-#define BGMT_FLASH_MOVIE             0xE4
-#define BGMT_PRESS_FLASH_MOVIE       0xE5
-#define BGMT_UNPRESS_FLASH_MOVIE     0xE6
-
-#define BGMT_ISO_MOVIE               0xE7
-#define BGMT_PRESS_ISO_MOVIE         0xE8
-#define BGMT_UNPRESS_ISO_MOVIE       0xE9
-/* kitor: Defs not used by ML 
+/* kitor: Defs not used by ML
  * MODE button: 0x35 PRESS, 0x36 UNPRESS
  * Backlight:   0x3D PRESS, 0x3E UNPRESS
  * LOCK:        0x92 LOCK , 0x93 UNLOCK
@@ -66,22 +57,22 @@
  * Star:        0x85 PRESS
  * Zoom/AF sel: 0x15 PRESS, 0x16 UNPRESS
  * Touch bar:   Between 0x4F and 0x56:
- * - press L    0x51 PRESS, 0x52 UNPRESS
- * - press R    0x4F PRESS, 0x50 UNPRESS
- * - swipe R    0x55 SWIPE, 0x50 on UNPRESS (as press R)
- * - swuoe K    0x56 SWIPE, 0x52 on UNPRESS (as press L)
- */ 
+ * - tap R      0x4F tap
+ * - lift R     0x50 lift (finger up on the right side)
+ * - tap L      0x51 tap
+ * - lift L     0x52 lift (finger up on the left side)
+ * - swipe R    0x55 repeats while moving finger in right direction
+ * - swipe L    0x56 repeats while moving finger in left direction
+ * "lift" events are generated both for taps and swipes. "swipe" events repeats
+ * based on distance traveled in given direction. One can swipe left and right,
+ * and correct events will be generated - like moving finger on laptop touchpad.
+ */
 
-/* WRONG: to be checked */
-// backtrace copyOlcDataToStorage call in gui_massive_event_loop
-#define GMT_OLC_INFO_CHANGED         59
+/* Codes below are WRONG: DNE in R */
+#define BGMT_LV                      -0xF3 // MILC, always LV.
 
-// needed for correct shutdown from powersave modes
-#define GMT_GUICMD_START_AS_CHECK    43
-#define GMT_GUICMD_OPEN_SLOT_COVER   40
-#define GMT_GUICMD_LOCK_OFF          38
-
-#define BTN_ZEBRAS_FOR_PLAYBACK      BGMT_FUNC // what button to use for zebras in Play mode
-#define BTN_ZEBRAS_FOR_PLAYBACK_NAME "FUNC"
-
+#define BGMT_PRESS_ZOOM_IN           -0xF4
+//#define BGMT_UNPRESS_ZOOM_IN         -0xF5
+//#define BGMT_PRESS_ZOOM_OUT          -0xF6
+//#define BGMT_UNPRESS_ZOOM_OUT        -0xF7
 #endif

--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -131,7 +131,7 @@ THUMB_FN(0xE00C6BC8,  task_trampoline)
 THUMB_FN(0xe02ebf38, _get_task_info_by_id)
 /*
  * kitor: via extask function. While on 5D3 it was called directly, now helper
- * is used. Find extask via string formats. Trace variables holding task id, 
+ * is used. Find extask via string formats. Trace variables holding task id,
  * you will quickly find where it is verified (this is the mentioned helper).
  * In the helper code you will find call to our stub.
  */
@@ -149,7 +149,7 @@ THUMB_FN(0xE0562ED0,  take_semaphore)                       /* SystemIF::KerSem.
 /** GUI **/
 DATA_PTR(    0xfcb4,  gui_task_list)                        // based on 200d
 THUMB_FN(0xe052f34c,  SetGUIRequestMode)                    // by debug message
-THUMB_FN(0xE004AD80,  gui_main_task)                        // task_create("GuiMainTask"...
+THUMB_FN(0xE004AD80,  gui_main_task)                        // via task_create("GuiMainTask"...
 THUMB_FN(0xe03ae6ea,  gui_massive_event_loop)               // various "GUICMD_"* strings
 THUMB_FN(0xE004AE96,  gui_enqueue_message)                  // via string "warning! QueueLength=" and "GUI::GUI.c" in one function
 /*
@@ -158,15 +158,15 @@ THUMB_FN(0xE004AE96,  gui_enqueue_message)                  // via string "warni
  */
 DATA_PTR(    0x5304,  gui_main_struct)
 
- /** Dialog API **/
- THUMB_FN(0xe0541db6,  dialog_redraw)                        // via xrefs to "pDialog->pSignature == m_pcSignature"
- THUMB_FN(0xe0524080,  dialog_set_property_str)
+/** Dialog API **/
+THUMB_FN(0xe0541db6,  dialog_redraw)                        // via xrefs to "pDialog->pSignature == m_pcSignature"
+THUMB_FN(0xe0524080,  dialog_set_property_str)
 
 /*
  * kitor: gui_init_end DNE on R180. It's the only diff in gui_main_task vs 200d.
  *
  * I was unable to find GUI_Control either. It should print debug message and
- * call e004ae96(0, param_1, param_2, param_3 ), which adds it to gui queue.
+ * call gui_enqueue_message(0, param_1, param_2, param_3 ), which adds it to gui queue.
  */
 
 /** GUI timers **/
@@ -275,7 +275,7 @@ DATA_PTR(    0xFE64, _pXCM);                                // param1 to XCM_Mak
  * Stubs needed for CONFIG_XCM_DEDICATED_LAYER
  */
 THUMB_FN(0xe0701f4a, refreshVrmsSurface);                   // by debug message. Renamed to VMIX_TransferRectangleToVram on Digic X
-DATA_PTR(    0xFE6C, display_refresh_needed)                // Easy to spot in RefreshVrmsSurface
+DATA_PTR(    0xFE6C, display_refresh_needed)                // Easy to spot in refreshVrmsSurface()
 
 /**
  * Structures needed for CONFIG_XCM_DEDICATED_LAYER. Specific for EOS R only!
@@ -293,18 +293,17 @@ DATA_PTR(   0x6F2BC, VMIX_LayersEnableArr);
  * 'rgb_vram_info = RENDERER_LayersArr[0];'
  **/
 //THUMB_FN(0xe0567322, RENDERER_InitializeScreen)           // by debug message. Not used in code, left for reference above.
-THUMB_FN(0xe00da8c0, XimrExe);                              //In RefreshVrmsSurface, just before "XimrExe" debug message
-DATA_PTR(    0xFDF0, winsys_sem);                           //Used in RefreshVrmsSurface around XimrExe call
+THUMB_FN(0xe00da8c0, XimrExe);                              // In RefreshVrmsSurface, just before "XimrExe" debug message
+DATA_PTR(    0xFDF0, winsys_sem);                           // Used in RefreshVrmsSurface around XimrExe call
 DATA_PTR(    0xFD98, _rgb_vram_info);
 
 /** Wrong on purpose **/
-DATA_PTR(       0x0,  LCD_Palette)                          // D8 has no indexed RGB buffers.
+DATA_PTR(       0x0,  LCD_Palette)                          // D6+ do use palletes to draw GUI, but it is hw rendered into RGBA
 
 /** App handlers **/
 /**
  * Those can usually be found by looking at function address passed to
- * WINSYS_CreateDialogBox_wrapper / WINSYS_CreateDialogBox, just after some
- * debug message
+ * WINSYS_CreateDialogBox_wrapper(), usually after a debug message.
  * For some reason those doesn't seem to show up on gui_task_list on D8
  * (LiveViewApp) or there are not on top (PlayMain)
  */
@@ -318,7 +317,7 @@ THUMB_FN(0xe038f1c6,  PlayMovieGuideApp_handler)            // in StartPlayMovie
  * Code that creates / stops given task from above, also saves dialog pointer
  * somewhere. This seems to be a better way to detect if given app is running.
  *
- * Pointers to result of WINSYS_CreateDialogBox() call in given function.
+ * Pointers to result of WINSYS_CreateDialogBox_wrapper() call in given function.
  */
 //DATA_PTR(  0xe5b4,  PlayMain_dialog)                      // in StartPlayMain()
 //DATA_PTR( 0x14284,  ShootOlcApp_dialog)                   // in StartShootOlcApp()
@@ -329,8 +328,10 @@ DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewA
 /**
  * UNUSED but referenced elsewhere
  **/
-
 //THUMB_FN(0xe0780cb8,  ctrlman_dispatch_event)
+//THUMB_FN(, WINSYS_CreateDialogBox_wrapper)                // Equiv. of `CreateDialogBox()`. Forces layer ID to 0 (GUI)
+//THUMB_FN(, WINSYS_CreateDialogBox)                        // Actual logic. Takes one more argument than CreateDialogBox() (layer ID)
+                                                            // On R, Layer 1 is used only by StartLiveViewAFFrameApp()
 
 /**
  * Stuff below should not be enabled. Looks that there are many hardcoded
@@ -339,15 +340,15 @@ DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewA
  */
 
 /** Engio **/
-// THUMB_FN(0x, _EngDrvOut)                                      // not found yet, can be wrapped to _engio_write if needed
-// THUMB_FN(0xE06B92B4, _engio_write)                            // via "Count < MAX_ENG_REG_NUM","EngineDS::DSEngIO.c" strings
-// THUMB_FN(0x,  shamem_read)                                    // not found yet
+// THUMB_FN(0x, _EngDrvOut)                                  // not found yet, can be wrapped to _engio_write if needed
+// THUMB_FN(0xE06B92B4, _engio_write)                        // via "Count < MAX_ENG_REG_NUM","EngineDS::DSEngIO.c" strings
+// THUMB_FN(0x,  shamem_read)                                // not found yet
 
 /** ResLock **/
-// THUMB_FN(0xE054761E,  CreateResLockEntry)                     // one that creates 0x24 structure with cls pointer to "LockEntry"
-//                                                               // and multiple "ResInfo" structures
-// THUMB_FN(0xE0547806,  LockEngineResources)                    // Takes LockEntry as input, creates "EFM_ERSC_STATIC" inside LockEntry
-// THUMB_FN(0xE05478A6,  UnLockEngineResources)                  // Takes LockEntry as input, releases semaphore from LockEntry field
+// THUMB_FN(0xE054761E,  CreateResLockEntry)                 // One that creates 0x24 structure with cls pointer to "LockEntry"
+//                                                           // and multiple "ResInfo" structures
+// THUMB_FN(0xE0547806,  LockEngineResources)                // Takes LockEntry as input, creates "EFM_ERSC_STATIC" inside LockEntry
+// THUMB_FN(0xE05478A6,  UnLockEngineResources)              // Takes LockEntry as input, releases semaphore from LockEntry content
 
 /** EDMAC **/
 // THUMB_FN(0x,  AbortEDmac)
@@ -355,8 +356,8 @@ DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewA
 // THUMB_FN(0x,  ConnectWriteEDmac)
 // THUMB_FN(0x,  RegisterEDmacAbortCBR)
 // THUMB_FN(0x,  UnregisterEDmacAbortCBR)
-// THUMB_FN(0xE0535A82,  RegisterEDmacCompleteCBR)               // Not sure. Many registered CBRs have "CompCBR" in debug print names
-// THUMB_FN(0xE0535E16,  UnregisterEDmacCompleteCBR)             // Uses same data structure as above. Replaces CBR with pointer to "do nothing" function.
+// THUMB_FN(0xE0535A82,  RegisterEDmacCompleteCBR)            // Not sure. Many registered CBRs have "CompCBR" in debug print names
+// THUMB_FN(0xE0535E16,  UnregisterEDmacCompleteCBR)          // Uses same data structure as above. Replaces CBR with pointer to "do nothing" function.
 // THUMB_FN(0x,  RegisterEDmacPopCBR)
 // THUMB_FN(0x,  UnregisterEDmacPopCBR)
 // THUMB_FN(0x,  SetEDmac)

--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -304,15 +304,27 @@ DATA_PTR(       0x0,  LCD_Palette)                          // D8 has no indexed
 /**
  * Those can usually be found by looking at function address passed to
  * WINSYS_CreateDialogBox_wrapper / WINSYS_CreateDialogBox, just after some
- * debug message */
-THUMB_FN(0xe04f71fc,  PlayMain_handler)                     // msg: "StartPlayMain"
-THUMB_FN(0xe024584e,  ShootOlcApp_handler)                  // msg: "StartShootOlcApp PushPalette(%d)"
-THUMB_FN(0xe03ec4cc,  LiveViewApp_handler)                  // msg: "StartLiveViewApp(%#x)"
-THUMB_FN(0xe02a9f58,  LiveViewShutterApp_handler)           // msg: "StartLiveViewShutterApp"
-THUMB_FN(0xe038f1c6,  PlayMovieGuideApp_handler)            // msg: "StartPlayMovieGuideApp"
+ * debug message
+ * For some reason those doesn't seem to show up on gui_task_list on D8
+ * (LiveViewApp) or there are not on top (PlayMain)
+ */
+THUMB_FN(0xe04f71fc,  PlayMain_handler)                     // in StartPlayMain()
+THUMB_FN(0xe024584e,  ShootOlcApp_handler)                  // in StartShootOlcApp()
+THUMB_FN(0xe03ec4cc,  LiveViewApp_handler)                  // in StartLiveViewApp()
+//THUMB_FN(0xe02a9f58,  LiveViewShutterApp_handler)         // in StartLiveViewShutterApp()
+THUMB_FN(0xe038f1c6,  PlayMovieGuideApp_handler)            // in StartPlayMovieGuideApp()
 
-THUMB_FN(0xe0842940,  TouchBarFeedBackApp_handler)          // msg: "StartTouchBarFeedBackApp"
-THUMB_FN(0xe0786d74,  LiveViewTouchBarApp_handler)          // msg: "StartLiveViewTouchBarApp"
+/**
+ * Code that creates / stops given task from above, also saves dialog pointer
+ * somewhere. This seems to be a better way to detect if given app is running.
+ *
+ * Pointers to result of WINSYS_CreateDialogBox() call in given function.
+ */
+//DATA_PTR(  0xe5b4,  PlayMain_dialog)                      // in StartPlayMain()
+//DATA_PTR( 0x14284,  ShootOlcApp_dialog)                   // in StartShootOlcApp()
+DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewApp()
+//DATA_PTR( 0x1bd58,  LiveViewShutterApp_dialog)            // in StartLiveViewShutterApp(), not sure if needed
+//DATA_PTR( 0x15750,  PlayMovieGuideApp_dialog)             // in StartPlayMovieGuideApp()
 
 /**
  * UNUSED but referenced elsewhere

--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -257,35 +257,45 @@ THUMB_FN(0xe05538a8, _prop_request_change)                  // "PropertyMgr.c", 
  * RGBA / Compositor functions and structures
  */
 
-/** Stubs only for FEATURE_COMPOSITOR_XCM **/
-THUMB_FN(0xe0701f4a, RefreshVrmsSurface);                   //via "refreshVrmsSurface" string. Renamed to VMIX_TransferRectangleToVram on Digic X
-DATA_PTR(    0xFE74, XCM_Inititialized);                    //Easy to spot in RefreshVrmsSurface
-DATA_PTR(    0xFE6C, display_refresh_needed)                //Easy to spot in RefreshVrmsSurface
+/**
+ * Things needed for CONFIG_COMPOSITOR_XCM.
+ *
+ * R uses two layers (GUI, focus overlays). WINSYS code swaps pointer in
+ * WINSYS structure (one we know as _rgb_vram_info) to select which layer to
+ * draw.
+ *
+ * With FEATURE_COMPOSITOR_XCM we ask XCM via XCM_GetSourceSurface to give us
+ * pointer to layer 0, which is more reliable.
+ */
+THUMB_FN(0xe00dde38, XCM_GetSourceSurface)                  // by debug message
+//THUMB_FN(0xe00ddc02, XCM_MakeContext)                     // by debug message. Not used in code, left for reference below.
+DATA_PTR(    0xFE64, _pXCM);                                // param1 to XCM_MakeContext() when called from refreshVrmsSurface()
 
-/*
- * Structures below are probably specific to EOSR implementation.
+/**
+ * Stubs needed for CONFIG_XCM_DEDICATED_LAYER
+ */
+THUMB_FN(0xe0701f4a, refreshVrmsSurface);                   // by debug message. Renamed to VMIX_TransferRectangleToVram on Digic X
+DATA_PTR(    0xFE6C, display_refresh_needed)                // Easy to spot in RefreshVrmsSurface
+
+/**
+ * Structures needed for CONFIG_XCM_DEDICATED_LAYER. Specific for EOS R only!
  * See https://www.magiclantern.fm/forum/index.php?topic=26024
  */
 DATA_PTR(   0x6EFA0, RENDERER_LayersArr);
 DATA_PTR(   0x6F2A4, VMIX_LayersArr);
 DATA_PTR(   0x6F2BC, VMIX_LayersEnableArr);
 
-/** General FEATURE_VRAM_RGBA stubs **/
+/**
+ * General FEATURE_VRAM_RGBA stubs
+ *
+ * _rgb_vram_info is a pointer to first Canon RGBA buffer (GUI).
+ * On R this is set up by RENDERER_InitializeScreen(), after MARVs are created:
+ * 'rgb_vram_info = RENDERER_LayersArr[0];'
+ **/
+//THUMB_FN(0xe0567322, RENDERER_InitializeScreen)           // by debug message. Not used in code, left for reference above.
 THUMB_FN(0xe00da8c0, XimrExe);                              //In RefreshVrmsSurface, just before "XimrExe" debug message
 DATA_PTR(    0xFDF0, winsys_sem);                           //Used in RefreshVrmsSurface around XimrExe call
-
-/*
- * Pointer to first Canon RGBA buffer (GUI). On R this is set up by
- * RENDERER_InitializeScreen function, just after MARVs are created.
- */
 DATA_PTR(    0xFD98, _rgb_vram_info);
-
-/*
- * Place where we can hook into RefreshVrmsSurface.
- * Found inside function called just before "GraphicSystemFinish" debug message.
- * Function should return int, takes no params. Found on M50, 200D, R6, RP too.
- */
-DATA_PTR(   0x1098c, screen_redraw_hook);
 
 /** Wrong on purpose **/
 DATA_PTR(       0x0,  LCD_Palette)                          // D8 has no indexed RGB buffers.

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -232,19 +232,16 @@ void refresh_yuv_from_rgb(void)
 
 static void refresh_yuv_from_rgb_task(void *unused)
 {
+    #ifdef CONFIG_COMPOSITOR_DEDICATED_LAYER
+    DryosDebugMsg(0, 15, "Canon layer: 0x%08x", rgb_vram_info);
+    // Try to initialize our layer.
+    compositor_layer_setup();
+    DryosDebugMsg(0, 15, "Our layer: 0x%08x", rgb_vram_info);
+    #endif
     TASK_LOOP
     {
         if (ml_refresh_display_needed && !ml_shutdown_requested && DISPLAY_IS_ON)
         {
-            #if (defined(CONFIG_R) || defined(CONFIG_EOSRP)) && !defined(FEATURE_COMPOSITOR_XCM)
-                /* kitor FIXME: R seems to do GUI double buffering or buffer swaps.
-                 * Somehow ML menus ended up on layer 1 - _rgb_vram_info pointer
-                 * had to change between ML init and runtime.
-                 * No such problem observed on 200D.
-                 */
-                if(_rgb_vram_info != rgb_vram_info)
-                    rgb_vram_info = _rgb_vram_info;
-            #endif
             refresh_yuv_from_rgb();
         }
         msleep(50); // max 20 fps refresh
@@ -713,6 +710,10 @@ getfilesize_fail:
 void clrscr()
 {
     BMP_LOCK( bmp_fill( 0x0, BMP_W_MINUS, BMP_H_MINUS, BMP_TOTAL_WIDTH, BMP_TOTAL_HEIGHT ); )
+    #ifdef CONFIG_COMPOSITOR_DEDICATED_LAYER
+    // clear our layer
+    compositor_layer_clear();
+    #endif
 }
 
 // this is slow, but is good for a small number of pixels :)

--- a/src/compositor.h
+++ b/src/compositor.h
@@ -7,15 +7,62 @@
 int compositor_layer_setup();
 void compositor_layer_clear();
 
-#if defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
-#define XCM_MAX_LAYERS 8
-#elif defined(CONFIG_DIGIC_VIII) || defined(CONFIG_DIGIC_X)
-#define XCM_MAX_LAYERS 6
-#endif
-/*
- * Just a pointer to MARV four our own layer, plus layer ID for toggling later.
+/**
+ * Really D8, DX -> 6, D7 -> 8, D6 -> either 7 or 8 depending on Zico fw.
+ *
+ * Limiting to 6 is OK as Canon code uses either 1 or 2 (GUI + Focus overlays),
+ * and so far we we alocate no more than one extra- still leaving headroom of 3.
  */
-extern int _rgb_vram_layer; // = 0;
-extern struct semaphore *compositor_vsync_semaphore;
+#define XIMR_MAX_LAYERS 6
+
+/**
+ * color / flags field contains at least 4 information, starting from MSB:
+ *
+ * 8 bits: Possibly Ximr type ID for color space.
+ * 8 bits: Bits per pixel?
+ * 8 bits: Subsampling factor?
+ * 1 bit : Flag if structure utilize that "separate opacity layer"
+ * 7 bits: Unknown / not referenced in any code I analyzed.
+ *
+ * "Bits per pixel" and "Subsampling factor" are used as follows in CreateMARV:
+ *
+ * BMP_VRAM_SIZE = fast_division(width * bits_per_pixel, subsampling_factor);
+ * BMP_VRAM_SIZE = BMP_VRAM_SIZE * height;
+ *
+ * Examples (real values from D678 ROMs):
+ *
+ * 0x11060200 UYVYAA:
+ *     0x11: type, 0x06: bytes per pixel, 0x02: subsampling factor,
+ *     no bit flag set for separate alpha layer
+ *
+ * 0x01040280 UYVY + alpha:
+ *     0x01: type, 0x04: bytes per pixel, 0x02: subsampling factor,
+ *     0x80 (10000000b) - use separate alpha
+ *
+ * 0x05040100 RGBA:
+ *     0x05: type, 0x04: bytes per pixel, 0x01: subsampling factor,
+ *     no bit flag for separate alpha layer
+ *
+ * On EOSR i was able to conduct a few experiments:
+ * 0x03000000 - nothing is drawn on screen.
+ * 0x04020100 - YUV without alpha channel.
+ * 0x02010100 - Also YUV, with half the data per pixel from above.
+ *
+ * WARNING: Early D6 cameras use other flag format. From EOS M10 (PowerShoot):
+ * 0x04000002, 0x05000004 and 0x07000002. This depends on Zico FW.
+ * I don't know any D6 EOS codebase models that do that, but if any is found,
+ * it will require an ifdef below.
+ *
+ * See https://www.magiclantern.fm/forum/index.php?topic=26024 for more details.
+ */
+#define XIMR_FLAGS_LAYER_RGBA 0x5040100
+
+// This shouldn't change, but...
+#ifndef CANON_GUI_LAYER_ID
+#define CANON_GUI_LAYER_ID 0
+#endif
+
+// ID of our allocated layer. See compositor.c for initialization.
+extern int _rgb_vram_layer_id; // = CANON_GUI_LAYER_ID;
 
 #endif

--- a/src/compositor.h
+++ b/src/compositor.h
@@ -4,9 +4,8 @@
 #include "vram.h"
 #include "bmp.h"
 
-int surface_setup();
-void rgba_fill(uint32_t color, int x, int y, int w, int h);
-void surface_clean();
+int compositor_layer_setup();
+void compositor_layer_clear();
 
 #if defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
 #define XCM_MAX_LAYERS 8
@@ -16,6 +15,7 @@ void surface_clean();
 /*
  * Just a pointer to MARV four our own layer, plus layer ID for toggling later.
  */
-extern int _rgb_vram_layer;// = 0;
+extern int _rgb_vram_layer; // = 0;
+extern struct semaphore *compositor_vsync_semaphore;
 
 #endif

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -271,11 +271,12 @@ SIZE_CHECK_STRUCT( dialog, 0x110 );
 #endif
 
 #else // =< DIGIC5
+// kitor: looks a bit similar to D67. By comparing with 5D3 I fixed a few mistakes.
 struct dialog
 {
         const char *            type;                   // "DIALOG" at 0x147F8
         struct window *         window;                 // off 0x04
-        void *                  arg0;                   // off 0x08
+        void *                  id;                     // off 0x08
         struct langcon *        langcon;                // off 0x0c
         struct dispsw_control * disp_sw_controller;     // off 0x10
         struct publisher *      publisher;              // off 0x14
@@ -309,12 +310,12 @@ struct dialog
         uint32_t                off_0x7c;               // initial=0
         struct publisher *      publisher_callback;     // off_0x80;
         uint32_t                off_0x84;
-        uint32_t                const_40000000_0;       // off_0x88;
-        uint32_t                off_0x8c;               // initial=0xA
-        uint32_t                off_0x90;               // initial=0xA
-        uint32_t                id;                     // off_0x94;
-        uint32_t                level_maybe;            // off_0x98;
-        uint32_t                const_40000000_1;       // off_0x9c;
+        uint32_t                color_related_1;        // Set to 0x40000000 in CreateDialogBox. Seems to be some kind of bitmask, color related.
+        uint32_t                some_x;                 // Another region, unknown meaning
+        uint32_t                some_y;                 // Set by default to 0,0,arg1,arg2 in CreateDialogBox
+        uint32_t                some_w;
+        uint32_t                some_h;
+        uint32_t                color_related_2;        // See color_related_1
         uint16_t                off_0xa0;               // initial=0
         uint16_t                off_0xa2;
         uint32_t                off_0xa4;
@@ -324,17 +325,35 @@ struct dialog
 
 SIZE_CHECK_STRUCT( dialog, 0xB0 );
 #endif
+
 /*
- * kitor: New generations call it WINSYS_CreateDialogBox()
- * EOS R has one more param at the end. Unconfirmed guess: z-index
+ * DIGIC8+ naming is WINSYS_CreateDialogBox
  */
 extern struct dialog *
 dialog_create(
-        int                     id,      // must be unique?
-        int                     level_maybe,
+        int                     width,         // region set as 10,10,width,height
+        int                     height,        // on dialog init
         dialog_handler_t        handler,
-        void *                  arg1,
-        void *                  arg2
+        int                     id,
+        void *                  handler_arg
+);
+
+/*
+ * Models that use multiple GUI layers have additional parameter with layer ID.
+ * Those also have a wrapper with hardcoded layer 0 (equiv to dialog_create),
+ * I guess for compatibility reasons (so all not-layer-aware code can run)
+ *
+ * On R/RP layer 1 is used just to draw focus overlays while in LV mode, only
+ * one app makes use of it.
+ */
+extern struct dialog *
+dialog_create_ex(
+        int                     width,         // region set as 10,10,width,height
+        int                     height,        // on dialog init
+        dialog_handler_t        handler,
+        int                     id,
+        void *                  handler_arg,
+        int                     layer_id       // GUI layer to draw window on
 );
 
 extern void

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -159,207 +159,118 @@ struct dialog_list
 
 
 /** Dialog box gui elements */
-#if defined(CONFIG_R) || defined(CONFIG_M50)
-// tested on R and M50. RP has slightly different size.
+#ifdef CONFIG_DIGIC_678
+// Verified on 750D (D6), 200D (D7), M50, R, RP, 250D (D8)
 struct dialog {
-    char * type;
-    struct window * window;
-    uint32_t arg4; /* 4th arg to WINSYS_CreateDialogBox, referenced as ID in some prints */
+    char * type;                                        // Signature, pointer to "DIALOG" string
+    struct window *          window;
+    uint32_t                 id;                        // 4th arg to CreateDialogBox, referenced as ID in some prints
     struct subscriberClass * hLanguageSubscriber;
-    struct subscriberClass * hTerminateSubscriber; /* disp_sw_controller? */
-    uint32_t refresh_x; /* rectangle to redraw? */
-    uint32_t refresh_y;
-    uint32_t refresh_w;
-    uint32_t refresh_h;
-    uint32_t origin_maybe; /* not sure, referenced as origin in messages */
-    uint32_t pos_x;
-    uint32_t pos_y;
-    uint32_t pos_w;
-    uint32_t pos_h;
-    uint32_t field_0x38;
-    uint32_t field_0x3c;
-    struct gui_task * controller; /* CtrlServ aka gui_task object */
-    uint8_t field_0x44;
-    uint8_t field_0x45;
-    uint8_t field_0x46;
-    uint8_t field_0x47;
-    uint32_t field_0x48;
-    uint32_t * field_0x4c;
-    uint32_t * field_0x50;
-    void * handler;
-    void * handler_arg;
-    uint32_t field_0x5c; /* set in WINSYS_GetFocusedItemIDOfDialogItem_maybe */
-    uint16_t field_0x60;
-    uint16_t field_0x62;
-    uint16_t field_0x64;
-    uint16_t field_0x66;
-    uint32_t field_0x68;
-    uint32_t field_0x6c;
-    uint32_t field_0x70;
-    uint8_t field_0x74;
-    uint8_t field_0x75;
-    uint8_t field_0x76;
-    uint8_t field_0x77;
-    uint32_t field_0x78;
-    uint32_t const_40000000_0; /* set in WINSYS_CreateDialogBox */
-    uint32_t some_w; /* see WINSYS_ResizeDialogBox_maybe */
-    uint32_t some_h;
-    uint32_t id; /* is id ID really? See 0x8, this is referenced as ID */
-    uint32_t level_maybe;
-    uint32_t const_40000000_1; /* set in WINSYS_CreateDialogBox */
-    uint16_t field_0x94;
-    uint8_t field_0x96;
-    uint8_t field_0x97;
-    void * child_list_maybe; /* buffer of (pointer size * count below) */
-    uint child_list_count_maybe; /* search table length %d; +2 from "real" size - see WINSYS_CreateDialogBox */
-    uint32_t reaction_x; /* see WINSYS_SetReactionAreaToDialog */
-    uint32_t reaction_y;
-    uint32_t reaction_w;
-    uint32_t reaction_h;
-    uint32_t field_0xb0;
-    uint32_t field_0xb4;
-    uint32_t field_0xb8;
-    uint32_t field_0xbc;
-    uint32_t field_0xc0;
-    uint16_t field_0xc4;
-    uint8_t field_0xc6;
-    uint8_t field_0xc7;
-    uint8_t field_0xc8;
-    uint8_t field_0xc9;
-    uint8_t field_0xca;
-    uint8_t field_0xcb;
-    uint32_t field_0xcc;
-    uint32_t field_0xd0;
-    uint16_t field_0xd4;
-    uint8_t field_0xd6;
-    uint8_t field_0xd7;
-    uint32_t field_0xd8;
-    uint32_t field_0xdc;
-    uint32_t field_0xe0;
-    uint32_t field_0xe4;
-    uint32_t field_0xe8;
-    uint32_t field_0xec;
-    uint32_t field_0xf0;
-    uint32_t field_0xf4;
-    uint32_t field_0xf8;
-    uint32_t field_0xfc;
-    uint32_t field_0x100;
-    uint32_t field_0x104;
-    uint32_t field_0x108;
-    uint32_t field_0x10c;
-    uint32_t field_0x110;
-    uint32_t field_0x114;
-    uint32_t field_0x118;
-    uint32_t rotationAngle;
+#if defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
+    uint32_t                 unk_d67_01;                // Not initialized in CreateDialogBox; type may be wrong
+#endif
+    struct subscriberClass * hTerminateSubscriber;      // disp_sw_controller?
+    uint32_t                 refresh_x;                 // Region to redraw? probably a "damaged" region.
+    uint32_t                 refresh_y;
+    uint32_t                 refresh_w;
+    uint32_t                 refresh_h;
+    uint32_t                 origin_maybe;              // not sure, referenced as origin in messages, may be resolution related ID
+    uint32_t                 pos_x;                     // Region of window onscreen position?
+    uint32_t                 pos_y;
+    uint32_t                 pos_w;
+    uint32_t                 pos_h;
+#ifdef CONFIG_DIGIC_VIII
+    uint32_t                 flag_1;                    // Set either 0 or 1. Defaults to 0.
+    uint32_t                 flag_2;                    // Set either 0 or 1. Defaults to 0.
+#endif // CONFIG_DIGIC_VIII
+    struct gui_task *        controller;                // CtrlServ object. We call it gui_task
+    void *                   dlgItem_related_1;
+    uint32_t                 unk_01;
+#if defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
+    uint8_t                  unk_d67_02[20];            // Not initialized in CreateDialogBox; Compacted to array, type surely wrong.
+#endif // defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
+    void *                   dlgItem_related_2;         // dlgItem_related_2 and _3 are set to dlgItem_related_1 in CreateDialogBox
+    void *                   dlgItem_related_3;         // Referenced in TerminateDialogBox, item[1] passed to DestroyDialogItem.
+    void *                   handler;                   // Pointer to CBR
+    void *                   handler_arg;               // Arg for CBR
+    uint32_t                 unk_02;                    // Set in WINSYS_GetFocusedItemIDOfDialogItem.
+    uint16_t                 short_x;                   // Another region. This one expressed in shorts insted of uint32_t
+    uint16_t                 short_y;                   // region may be connected with resources loading, called from ResLoad function
+    uint16_t                 short_w;                   // where it returns XYWH to resource structure.
+    uint16_t                 short_h;
+    uint32_t                 unk_03;
+    uint32_t                 unk_04;
+    uint32_t                 unk_05;
+    uint8_t                  unk_06;                    // Not initialized in CreateDialogBox; type may be wrong
+    uint8_t                  unk_07;                    // ^ like above
+    uint8_t                  unk_08;                    // ^ like above
+    uint8_t                  unk_09;                    // ^ like above
+    uint32_t                 unk_10;
+    uint32_t                 color_related_1;           // Set to 0x40000000 in CreateDialogBox. Seems to be some kind of bitmask, color related.
+    uint32_t                 some_x;                    // Another region, unknown meaning
+    uint32_t                 some_y;                    // Set by default to 0,0,arg1,arg2 in CreateDialogBox
+    uint32_t                 some_w;
+    uint32_t                 some_h;
+    uint32_t                 color_related_2;           // See color_related_1
+    uint16_t                 unk_11;
+    uint8_t                  unk_12;
+    uint8_t                  unk_13;
+    void *                   child_list;                // Pointer to buffer of (sizeof(ptr) * child_list_count_maybe)
+    uint                     child_list_count;          // "search table length %d"; +2 from "real" size - see CreateDialogBox
+    uint32_t                 reaction_x;                // Region. See SetReactionAreaToDialog
+    uint32_t                 reaction_y;
+    uint32_t                 reaction_w;
+    uint32_t                 reaction_h;
+    uint32_t                 unk_14;
+    uint32_t                 unk_15;
+    uint32_t                 unk_16;
+    uint32_t                 unk_17;
+    uint32_t                 unk_18;
+    uint16_t                 unk_19;
+    uint8_t                  unk_20;                    // Not initialized in CreateDialogBox; type may be wrong
+    uint8_t                  unk_21;                    // ^ like above
+    uint8_t                  unk_22;                    // ^ like above
+    uint8_t                  unk_23;                    // ^ like above
+    uint8_t                  unk_24;                    // ^ like above
+    uint8_t                  unk_25;                    // ^ like above
+    uint32_t                 unk_26;
+    uint32_t                 unk_27;
+    uint16_t                 unk_28;
+    uint8_t                  unk_29;                    // Not initialized in CreateDialogBox; type may be wrong
+    uint8_t                  unk_30;                    // ^ like above
+    uint32_t                 unk_31;
+    uint32_t                 unk_32;
+    uint32_t                 unk_33;
+    uint32_t                 unk_34;
+    uint32_t                 unk_35;
+    uint32_t                 unk_36;
+    uint32_t                 unk_37;
+    uint32_t                 unk_38;
+    uint32_t                 unk_39;
+    uint32_t                 unk_40;
+#ifdef CONFIG_DIGIC_VIII                                // DIGIC8
+    uint32_t                 _refresh_x;                // Region used as arguments passed to WINSYS_RegisterRefreshRectangle_maybe
+    uint32_t                 _refresh_y;                // which updates refresh_[xywh] conditionally from those values.
+    uint32_t                 _refresh_w;
+    uint32_t                 _refresh_h;
+    uint32_t                 unk_d8_01;
+    uint32_t                 unk_d8_02;
+    uint32_t                 unk_d8_03;
+    uint32_t                 rotationAngle;             // Guess: GUI can render rotated 90 degrees (EVF)
+    //uint32_t               field_0x122;               // Those two exists on RP and later. We don't use them, and
+    //uint32_t               field_0x124;               // do not create struct so I left them commented out.
+#endif // CONFIG_DIGIC_VIII
 };
-#elif defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
-// confirmed on 750D, 200D
-struct dialog {
-    const char * type; //class, pSignature
-    void * hWindow;
-    uint32_t id;
-    void * hLanguageSubscriber;
-    uint8_t field_0x10;
-    uint8_t field_0x11;
-    uint8_t field_0x12;
-    uint8_t field_0x13;
-    void * hTerminateSubscriber;
-    uint32_t field_0x18;
-    uint32_t field_0x1c;
-    uint32_t field_0x20;
-    uint32_t field_0x24;
-    uint32_t field_0x28;
-    uint32_t field_0x2c;
-    uint32_t field_0x30;
-    uint32_t field_0x34;
-    uint32_t field_0x38;
-    void * controller;
-    uint8_t field_0x40;
-    uint8_t field_0x41;
-    uint8_t field_0x42;
-    uint8_t field_0x43;
-    uint32_t field_0x44;
-    uint8_t field_0x48;
-    uint8_t field_0x49;
-    uint8_t field_0x4a;
-    uint8_t field_0x4b;
-    uint8_t field_0x4c;
-    uint8_t field_0x4d;
-    uint8_t field_0x4e;
-    uint8_t field_0x4f;
-    uint8_t field_0x50;
-    uint8_t field_0x51;
-    uint8_t field_0x52;
-    uint8_t field_0x53;
-    uint8_t field_0x54;
-    uint8_t field_0x55;
-    uint8_t field_0x56;
-    uint8_t field_0x57;
-    uint8_t field_0x58;
-    uint8_t field_0x59;
-    uint8_t field_0x5a;
-    uint8_t field_0x5b;
-    uint32_t * field_0x5c;
-    uint32_t * field_0x60;
-    void * handler;
-    void * handler_arg;
-    uint32_t field_0x6c;
-    uint16_t field_0x70;
-    uint16_t field_0x72;
-    uint16_t field_0x74;
-    uint16_t field_0x76;
-    uint32_t field_0x78;
-    uint32_t field_0x7c;
-    uint32_t field_0x80;
-    uint8_t field_0x84;
-    uint8_t field_0x85;
-    uint8_t field_0x86;
-    uint8_t field_0x87;
-    uint32_t field_0x88;
-    uint32_t color_related_1;
-    uint32_t unknown_region_x;
-    uint32_t unknown_region_y;
-    uint32_t unknown_region_w;
-    uint32_t unknown_region_h;
-    uint32_t color_related_2;
-    uint16_t field_0xa4;
-    uint8_t field_0xa6;
-    uint8_t field_0xa7;
-    void * child_list_maybe;
-    int child_list_count_maybe;
-    uint32_t field_0xb0;
-    uint32_t field_0xb4;
-    uint32_t field_0xb8;
-    uint32_t field_0xbc;
-    uint32_t field_0xc0;
-    uint32_t field_0xc4;
-    uint32_t field_0xc8;
-    uint32_t field_0xcc;
-    uint32_t field_0xd0;
-    uint16_t field_0xd4;
-    uint8_t field_0xd6;
-    uint8_t field_0xd7;
-    uint8_t field_0xd8;
-    uint8_t field_0xd9;
-    uint8_t field_0xda;
-    uint8_t field_0xdb;
-    uint32_t field_0xdc;
-    uint32_t field_0xe0;
-    uint16_t field_0xe4;
-    uint8_t field_0xe6;
-    uint8_t field_0xe7;
-    uint32_t field_0xe8;
-    uint32_t field_0xec;
-    uint32_t field_0xf0;
-    uint32_t field_0xf4;
-    uint32_t field_0xf8;
-    uint32_t field_0xfc;
-    uint32_t field_0x100;
-    uint32_t field_0x104;
-    uint32_t field_0x108;
-    uint32_t field_0x10c;
-};
+
+#ifdef CONFIG_DIGIC_VIII
+// RP, 250D is 0x128, but we left two commented out as they are not needed
+SIZE_CHECK_STRUCT( dialog, 0x120 );
 #else
+// verified on 750D, 200D
+SIZE_CHECK_STRUCT( dialog, 0x110 );
+#endif
+
+#else // =< DIGIC5
 struct dialog
 {
         const char *            type;                   // "DIALOG" at 0x147F8

--- a/src/init.c
+++ b/src/init.c
@@ -265,7 +265,6 @@ static void draw_test_pattern(int colour)
 }
 
 #ifdef FEATURE_VRAM_RGBA
-extern int ml_refresh_display_needed;
 
 /** kitor: This aint pretty, but we selectively call bmp init functions
  *  and run required tasks. Other solution would be to have function in bmp.c

--- a/src/init.c
+++ b/src/init.c
@@ -33,9 +33,6 @@
 #include "property.h"
 #include "consts.h"
 #include "tskmon.h"
-#ifdef FEATURE_COMPOSITOR_XCM
-#include "compositor.h"
-#endif
 
 #include "boot-hack.h"
 #include "ml-cbr.h"
@@ -409,11 +406,6 @@ static void my_big_init_task()
 {
     _mem_init();
     _find_ml_card();
-
-    #ifdef FEATURE_COMPOSITOR_XCM
-    while (surface_setup())
-        msleep(100);
-    #endif
 
     /* should we require SET for loading ML, or not? */
     extern int _set_at_startup;

--- a/src/lens.c
+++ b/src/lens.c
@@ -1828,9 +1828,6 @@ void _prop_lv_lens_request_update()
 #endif
 
 #ifdef CONFIG_DIGIC_VIII
-#define DYNAMIC_FLAG_ST2_MF    0x80  // true -> MF, false -> AF
-#define DYNAMIC_FLAG_ST3_IS    0x0F  // looks PROP_LV_LENS_STABILIZE equiv.
-
 PROP_HANDLER( PROP_LENS_DYNAMIC_DATA )
 {
     if(len != sizeof(struct prop_lens_dynamic_data))
@@ -1838,10 +1835,10 @@ PROP_HANDLER( PROP_LENS_DYNAMIC_DATA )
 
     const struct prop_lens_dynamic_data * const _dynamic = (void*) buf;
     lens_info.focal_len        = _dynamic->FL;
-    lens_info.IS               = (_dynamic->st3 & DYNAMIC_FLAG_ST3_IS);
+    lens_info.IS               = (_dynamic->st3 & 0xF); //last 8 bits looks like PROP_LV_LENS_STABILIZE equiv.
 
     // This can be used to fake PROP_AF_MODE. Works only on lenses with physical AF/MF switch.
-    //af_mode = (_dynamic->st2 & DYNAMIC_FLAG_ST2_MF) ? AF_MODE_MANUAL_FOCUS : AF_MODE_ONE_SHOT;
+    //af_mode = (_dynamic->st2 & 0x80) ? AF_MODE_MANUAL_FOCUS : AF_MODE_ONE_SHOT; // true -> MF, false -> AF
 
     /*
     // Disabled for now. Requires lens_info rewrite due to storage size change

--- a/src/lens.c
+++ b/src/lens.c
@@ -1232,41 +1232,36 @@ PROP_HANDLER( PROP_LENS_STATIC_DATA )
 {
     ASSERT(len == sizeof(struct prop_lens_static_data));
 
-    const struct prop_lens_static_data * lens_data = (void*) buf;
+    const struct prop_lens_static_data * _static = (void*) buf;
 
-    strncpy( lens_info.name, lens_data->lens_name, sizeof(lens_info.name) );
+    strncpy( lens_info.name, _static->lens_name, sizeof(lens_info.name) );
     lens_info.name[sizeof(lens_info.name) - 1] = '\0'; //null terminate
 
-    lens_info.lens_exists      = lens_data->attached;
-    lens_info.raw_aperture_min = lens_data->av_min_spd;
-    lens_info.raw_aperture_max = lens_data->av_max_spd;
-    lens_info.lens_id          = lens_data->lens_id;
-    lens_info.lens_focal_min   = lens_data->fl_wide;
-    lens_info.lens_focal_max   = lens_data->fl_tele;
-    lens_info.lens_extender    = lens_data->extender_id[0];
+    lens_info.lens_exists      = _static->attached;
+    // those are not RAW values! RAW are available in PROP_LENS_DYNAMIC_DATA
+    //lens_info.raw_aperture_min = _static->av_min_spd;
+    //lens_info.raw_aperture_max = _static->av_max_spd;
+    lens_info.lens_id          = _static->lens_id;
+    lens_info.lens_focal_min   = _static->fl_wide;
+    lens_info.lens_focal_max   = _static->fl_tele;
+    lens_info.lens_extender    = _static->extender_id[0];
 
-    lens_info.IS               = lens_data->lens_is_funct_exists;
+    lens_info.IS               = _static->lens_is_funct_exists;
 
      //not sure?
     lens_info.lens_version      = 0;
-    lens_info.lens_capabilities = lens_data->type; //Wrong, let's display type.
+    lens_info.lens_capabilities = _static->type; //Wrong, let's display type.
 
     uint32_t lens_serial_lo =
-         lens_data->lens_serial[4]        |
-        (lens_data->lens_serial[3] << 8)  |
-        (lens_data->lens_serial[2] << 16) |
-        (lens_data->lens_serial[1] << 24) ;
+         _static->lens_serial[4]        |
+        (_static->lens_serial[3] << 8)  |
+        (_static->lens_serial[2] << 16) |
+        (_static->lens_serial[1] << 24) ;
     uint32_t lens_serial_hi =
-        lens_data->lens_serial[0]         ;
+        _static->lens_serial[0]         ;
     lens_info.lens_serial =
          (uint64_t) lens_serial_lo |
         ((uint64_t) lens_serial_hi << 32);
-
-    if (lens_info.raw_aperture < lens_info.raw_aperture_min || lens_info.raw_aperture > lens_info.raw_aperture_max)
-    {
-        int raw = COERCE(lens_info.raw_aperture, lens_info.raw_aperture_min, lens_info.raw_aperture_max);
-        lensinfo_set_aperture(raw); // valid limits changed
-    }
 }
 #else
 

--- a/src/lens.h
+++ b/src/lens.h
@@ -206,70 +206,191 @@ SIZE_CHECK_STRUCT( prop_lv_lens, 58 );
 #endif
 
 #ifdef CONFIG_DIGIC_VIII
-/* kitor: Modeled after EOS R implementation. EvProc readid is very useful.
- * I collapsed huge chunks of unknown data into arrays for readability. */
-struct prop_lens_static_data {
+// TODO: expand for DIGIC X in future
+/* Digic 8 brings new properties:
+ * PROP_LENS_STATIC_DATA  = PROP_LENS + PROP_LENS_NAME + ???
+ * PROP_LENS_DYNAMIC_DATA = PROP_LV_LENS + ???
+ *
+ * Those are quite huge, they size depend on camera.
+ * So far we have data from M50, 250D, 850D, R, RP and (bonus) R6.
+ *             M50      R     RP    250D   850D    R6
+ * STATIC     0x138   0x184  0x184  0x180  0x1C8  0x1C8
+ * DYNAMIC    0x84    0x90   0x90   0x8C   0x90   0x94
+ * DryOS ICU   P2      P4     P4     P5     P8     P9
+ *
+ * A lot of PROP_LENS_STATIC_DATA can be decoded via `readid` evshell function.
+ *
+ * Structs seems to have `packed` attribute set, thus fields moving left and
+ * right between models. For easier debugging I left those paddings filled in.
+ */
+
+#if defined(CONFIG_M50) || defined(CONFIG_R) || defined(CONFIG_EOSRP) || defined (CONFIG_250D)
+// variants M50, R + RP, 250D combined
+struct prop_lens_static_data
+{
         uint8_t                 attached;
-        uint8_t                 type; /* 90 EF, 91 RF */
-            uint8_t                 field_0x2[38];
+        uint8_t                 type;                         // 90 EF, 91 RF
+        uint8_t                _unk_01[38];                   // Not referenced in readid
         uint16_t                lens_id;
         uint16_t                lens_id_ext;
         uint16_t                fl_wide;
         uint16_t                fl_tele;
         uint8_t                 lens_serial[5];
-            uint8_t                 field_0x35[24];
+        uint8_t                _unk_02[24];                    // Not referenced in readid
         uint8_t                 extender_id[6];
         uint8_t                 lens_firm_ver[3];
         uint8_t                 field_vision;
         uint8_t                 lens_type;
-            uint8_t                 field_0x58;
+#if defined(CONFIG_R) || defined(CONFIG_EOSRP)
+        uint8_t                _pad_01;                        // padding exists on R,RP
+#endif // !defined(CONFIG_250D) || !defined(CONFIG_M50)
         uint8_t                 lens_name_len;
         char                    lens_name[73];
-            uint8_t                 field_0xa3;
+        uint8_t                _unk_03;                        // Not referenced in readid
         uint8_t                 mount_size;
         uint8_t                 lens_switch_exists;
         uint8_t                 lens_is_switch_exists;
         uint8_t                 lens_is_funct_exists;
         uint8_t                 af_speed_setting_available;
+#if !defined(CONFIG_M50)
         uint8_t                 dafLimitFno;
         uint8_t                 distortionCorrectionInfo;
         uint8_t                 bcfInfo;
-            uint8_t                 field_0xac;
-            uint8_t                 field_0xad;
+        uint8_t                _unk_04;                        // Not referenced in readid
+#if !defined(CONFIG_250D)
+        uint8_t                _pad_02;                        // padding exists only on 250D
+#endif // !defined(CONFIG_250D)
+#endif // !defined(CONFIG_M50)
         uint16_t                zoom_pos_size;
         uint16_t                focus_pos_size;
         uint16_t                fine_focus_size;
+#if !defined(CONFIG_M50)
         uint8_t                 av_dlp_lens;
         uint8_t                 av_slow_enable;
+#endif
         uint8_t                 av_slow_div;
-            uint8_t                 field_0xb7;
+        uint8_t                _unk_05;                        // Not referenced in readid
         uint16_t                av_max_spd;
         uint16_t                av_silent_spd;
         uint16_t                av_min_spd;
-            uint8_t                 field_0xbe[151];
+#if defined(CONFIG_M50)
+        uint8_t                _unk_06[95];                    // Not referenced in readid
+#elif defined(CONFIG_250D)
+        uint8_t                _unk_06[149];                   // Not referenced in readid
+#else // R, RP, looks like additional padding vs 250D exists
+        uint8_t                _unk_06[151];                   // Not referenced in readid
+#endif
         uint8_t                 colorBalance;
         uint8_t                 pza_exists;
         uint8_t                 pza_id[5];
         uint8_t                 pza_firm_ver[3];
         uint8_t                 pza_firmup;
         uint8_t                 dlAdp_count;
-            uint8_t                 field_0x161;
-            uint8_t                 field_0x162;
-            uint8_t                 field_0x163;
+        uint8_t                _unk_07[3];                     // Not referenced in readid
         uint32_t                dlAdpl_id;
         uint8_t                 dlAdpl_funcl;
         uint8_t                 dlAdpl_firm_ver[3];
         uint32_t                dlAdpl2_id;
         uint8_t                 dlAdpl2_funcl;
         uint8_t                 dlAdpl2_firm_ver[3];
-            uint8_t                 field_0x174;
+        uint8_t                 safemode_info;                 // named only on M50
+        uint8_t                 demandWarnDispFromLens;        // unnamed on M50
+        uint8_t                 demandWarnDispFromAdp;         // unnamed on M50
+#if defined(CONFIG_M50)
+        uint8_t                _unk_08;                        // Not referenced in readid
+#else
+        uint8_t                _unk_08[13];                    // Not referenced in readid
+#endif
+};
+
+#if defined(CONFIG_M50)
+SIZE_CHECK_STRUCT( prop_lens_static_data, 0x138 );
+#elif defined(CONFIG_250D)
+SIZE_CHECK_STRUCT( prop_lens_static_data, 0x180 );
+#else  // R, RP
+SIZE_CHECK_STRUCT( prop_lens_static_data, 0x184 );
+#endif // size check M50, R, RP, 250D
+
+#elif defined(CONFIG_850D) || defined(CONFIG_R6)
+/* new struct variant reorders some fields as compared to previous
+ * thus making a separate definition */
+struct prop_lens_static_data
+{
+        uint8_t                 attached;
+        uint8_t                 type;
+        uint8_t                _unk_01[38];                    // Not referenced in readid
+        uint16_t                lens_id;
+        uint16_t                lens_id_ext;
+        uint16_t                fl_wide;
+        uint16_t                fl_tele;
+        uint8_t                 lens_serial[5];
+        uint8_t                _unk_02[24];                    // Not referenced in readid
+        uint8_t                 extender_id[6];
+        uint8_t                 lens_firm_ver[3];
+        uint8_t                 field_vision;
+        uint8_t                 lens_type;
+        uint8_t                 extenderMountInfo;
+        uint8_t                 lens_name_len;
+        char                    lens_name[73];
+        uint8_t                _unk_03[65];                    // Not referenced in readid
+        uint8_t                 mount_size;
+        uint8_t                 lens_switch_exists;
+        uint8_t                 lens_af_func_exists;
+        uint8_t                 lens_mf_funct_exists;
+        uint8_t                 lens_is_switch_exists;
+        uint8_t                 lens_is_funct_exists;
+        uint8_t                 af_speed_setting_available;
+        uint8_t                 dafLimitFno;
+        uint8_t                 distortionCorrectionInfo;
+        uint8_t                 bcfInfo;
+        uint8_t                 lens_id_1292;
+        uint8_t                 emd_hot_limit;
+#if defined(CONFIG_R6)
+        uint8_t                 aberationControl;              // DNE on 850D
+        uint8_t                 _pad_01;
+#endif // defined(CONFIG_R6)
+        uint16_t                zoom_pos_size;
+        uint16_t                focus_pos_size;
+        uint16_t                fine_focus_size;
+        uint16_t                av_slow_div;
+        uint8_t                 av_slow_enable;
+        uint8_t                 av_dlp_lens;
+        uint16_t                av_dlp_max_spd;
+        uint16_t                av_dlp_silent_spd;
+        uint16_t                av_dlp_min_spd;
+        uint8_t                _unk_04[150];
+        uint8_t                 extendMagnificationVal;
+        uint8_t                _unk_05;
+        uint16_t                ois_shift_max;
+#if defined(CONFIG_R6)
+        uint8_t                 colorBalance;                  // DNE on 850D
+#endif // defined(CONFIG_R6)
+        uint8_t                 pza_exists;
+        uint8_t                 pza_id[5];
+        uint8_t                 pza_firm_ver[3];
+        uint8_t                 pza_firmup;
+        uint8_t                 dlAdp_count;
+#if defined(CONFIG_850D)
+        uint8_t                _pad_02[3];
+#endif //defined(CONFIG_850D)
+        uint32_t                dlAdpl_id;
+        uint8_t                 dlAdpl_funcl;
+        uint8_t                 dlAdpl_firm_ver[3];
+        uint32_t                dlAdpl2_id;
+        uint8_t                 dlAdpl2_funcl;
+        uint8_t                 dlAdpl2_firm_ver[3];
+        uint8_t                _unk_06;
         uint8_t                 demandWarnDispFromLens;
         uint8_t                 demandWarnDispFromAdp;
-            uint8_t                 field_0x177[13];
-} __attribute__((packed));
+        uint8_t                _unk_07[13];
+};
 
-SIZE_CHECK_STRUCT( prop_lens_static_data, 388 );
-#endif
+SIZE_CHECK_STRUCT( prop_lens_static_data, 0x1C8 );
+#else  // unknown model
+#error No PROP_LENS_STATIC_DATA defined for built cam model
+#endif // unknown model
+
+#endif // CONFIG_DIGIC_VIII
 
 struct prop_focus
 {

--- a/src/menu.c
+++ b/src/menu.c
@@ -40,8 +40,6 @@
 #include "lvinfo.h"
 #include "powersave.h"
 
-extern uint32_t ml_refresh_display_needed;
-
 #define CONFIG_MENU_ICONS
 //~ #define CONFIG_MENU_DIM_HACKS
 #undef SUBMENU_DEBUG_JUNKIE

--- a/src/menu.c
+++ b/src/menu.c
@@ -42,10 +42,6 @@
 
 extern uint32_t ml_refresh_display_needed;
 
-#ifdef FEATURE_COMPOSITOR_XCM
-#include "compositor.h"
-#endif
-
 #define CONFIG_MENU_ICONS
 //~ #define CONFIG_MENU_DIM_HACKS
 #undef SUBMENU_DEBUG_JUNKIE
@@ -5642,16 +5638,7 @@ static void menu_close()
     clrscr();
     #endif
 
-    #ifdef FEATURE_COMPOSITOR_XCM
-    /*
-     * kitor: FIXME: this is needed until RGB8->RGBA translation will learn
-     * alpha channel, so RGB8 surface wipe would be possible.
-     * With own layers there's no Canon code to overwrite buffer on exit.
-     */
-    surface_clean();
-    #else
     redraw();
-    #endif
 
     if (lv)
         bmp_on();

--- a/src/property.h
+++ b/src/property.h
@@ -65,6 +65,8 @@
 #define PROP_LIVE_VIEW_FACE_AF  0x0205000A
 #define PROP_LV_LOCK            0x80050021
 #define PROP_LV_ACTION          0x80050022 // 0 == LV_START, 1 == LV_STOP
+#define PROP_LV_LCD_OVERLAY_ID  0x02050039 // Updated with LvInfoToggle index while in LCD
+#define PROP_LV_EVF_OVERLAY_ID  0x0205003A // Updated with LvInfoToggle index while in EVF
 
 /** These are guesses */
 #define PROP_LCD_POSITION       0x80040020 // 0 = like on non-flippable, 1 = backwards, 2 = flipped outside

--- a/src/property.h
+++ b/src/property.h
@@ -165,6 +165,7 @@
 #define PROP_DISPSENSOR_CTRL    0x80020010      // 1 == show results?
 #define PROP_LV_OUTPUT_DEVICE   0x80050011      // 1 == LCD?
 #define PROP_HOUTPUT_TYPE       0x80030030      // 0 = no info displayed in LV, 1 = info displayed (this is toggled with DISP)
+#define PROP_LV_OUTPUT_TYPE     0x80030030      // Real name of HOUTPUT_TYPE, as seen on D6+. Old name left for LUA compatibility.
 #define PROP_MIRROR_DOWN        0x8005001C
 #define PROP_MYMENU_LISTING     0x80040009
 

--- a/src/property.h
+++ b/src/property.h
@@ -74,6 +74,7 @@
 #define PROP_MVR_MOVW_START0    0x80000020 // not sure?
 #define PROP_MVR_MOVW_START1    0x80000021
 #define PROP_AF_MODE            0x80000004
+#define PROP_LVAF_MODE          0x80000050 // same values as PROP_AF_MODE
 #define AF_MODE_ONE_SHOT        0
 #define AF_MODE_MANUAL_FOCUS    3
 #define AF_MODE_AI_FOCUS        202        // TODO: seems to be model-specific or bit operation
@@ -182,7 +183,7 @@
 #define PROP_DEFAULT_BRACKET    0x8002000A
 #define PROP_PARTIAL_SETTING    0x8002000B
 #define PROP_EMPOWER_OFF        0x80030007      // 1 == prohibit, 2 == permit
-#define PROP_LVAF_MODE      0x8004001d // 0 = shutter killer, 1 = live mode, 2 = face detect
+#define PROP_LVAF_550D          0x8004001d      // 0 = shutter killer, 1 = live mode, 2 = face detect; introduced by a1ex on 550D branch
 
 #define PROP_ACTIVE_SWEEP_STATUS 0x8002000C     // 1 == cleaning sensor?
 

--- a/src/property.h
+++ b/src/property.h
@@ -310,8 +310,10 @@
 #define ALO_HIGH 2
 #define ALO_OFF 3
 
-#if defined(CONFIG_5D3)
+// was guarded for 5D3 / 6D, but R series seem to use it too.
 #define PROP_HTP 0x8000004a
+
+#if defined(CONFIG_5D3)
 #define PROP_MULTIPLE_EXPOSURE 0x0202000c
 #define PROP_MLU 0x80000047
 #endif
@@ -330,7 +332,6 @@
 
 #ifdef CONFIG_6D //May work for others.
 #define PROP_HI_ISO_NR 0x80000049 //Len 4, 4 is multishot
-#define PROP_HTP 0x8000004a
 #define PROP_MULTIPLE_EXPOSURE 0x0202000c
 #define PROP_MULTIPLE_EXPOSURE_SETTING 0x8000003F
 #define PROP_MLU 0x80000047

--- a/src/property.h
+++ b/src/property.h
@@ -81,6 +81,14 @@
 #define AF_MODE_AI_SERVO        101        // TODO: seems to be model-specific or bit operation
 #define PROP_MVR_REC            0x80030002
 #define PROP_LV_LENS            0x80050000
+/* As names_are_hard found, PROP_LV_LENS_D67 exists on D6/7 models.
+ * On D6/D7 PROP_LV_LENS_D67 is getting updated in LV. However there's no known
+ * method to force it update outside LV.
+ * But there's EvProc called msub.lensdata which result in PROP_LV_LENS update,
+ * however works only outside (!) LV.
+ * Thus for Digic 6 and 7 we need to use both properties.
+ */
+#define PROP_LV_LENS_D67        0x8008003c
 #define PROP_LV_0004            0x80050004
 #define PROP_LV_LENS_STABILIZE  0x80050005 // 0 = off, e0000 = on
 #define PROP_LV_MANIPULATION    0x80050006

--- a/src/propvalues.c
+++ b/src/propvalues.c
@@ -100,11 +100,17 @@ volatile PROP_INT(PROP_PIC_QUALITY2, pic_quality);
 volatile PROP_INT(PROP_PIC_QUALITY, pic_quality);
 #endif
 volatile PROP_INT(PROP_AVAIL_SHOT, avail_shot);
+#if defined(CONFIG_DIGIC_VIII)
+/* R uses PROP_LVAF_MODE. However code suggests that both may be used
+ * on DSLRs. When both are enabled, there's a race, so this is left to
+ * be tested on 250D/850D/etc. */
+volatile PROP_INT(PROP_LVAF_MODE, af_mode);
+#else
 volatile PROP_INT(PROP_AF_MODE, af_mode);
+#endif
 volatile PROP_INT(PROP_METERING_MODE, metering_mode);
 volatile PROP_INT(PROP_DRIVE, drive_mode);
 volatile PROP_INT(PROP_STROBO_FIRING, strobo_firing);
-volatile PROP_INT(PROP_LVAF_MODE, lvaf_mode);
 volatile PROP_INT(PROP_IMAGE_REVIEW_TIME, image_review_time);
 volatile PROP_INT(PROP_MIRROR_DOWN, mirror_down);
 volatile PROP_INT(PROP_LCD_BRIGHTNESS, backlight_level);

--- a/src/propvalues.c
+++ b/src/propvalues.c
@@ -300,8 +300,12 @@ void set_recording_custom(int state)
 
 int lv_disp_mode;
 
-#ifndef CONFIG_EOSM //~ we update lv_disp_mode from 
-PROP_HANDLER(PROP_HOUTPUT_TYPE)
+#ifndef LV_OVERLAYS_MODE
+/*
+ * For models with LV_OVERLAYS_MODE defined we update in zebra.c instead.
+ * See zebra.c `get_global_draw()` for more details.
+ */
+PROP_HANDLER(PROP_LV_OUTPUT_TYPE)
 {
     #if defined(CONFIG_5D3)
     /* 1 when Canon overlays are present on the built-in LCD, 0 when they are not present (so we can display our overlays) */
@@ -315,11 +319,6 @@ PROP_HANDLER(PROP_HOUTPUT_TYPE)
     #else
     lv_disp_mode = (uint8_t)buf[0];
     #endif
-
-    #ifdef CONFIG_5D2 // PROP_HOUTPUT_TYPE not reported correctly?
-    lv_disp_mode = (MEM(0x34894 + 0x48) != 3); // AJ_LDR_0x34894_guess_HDMI_disp_type_related_0x48
-    #endif
-
 }
 #endif
 

--- a/src/shoot.c
+++ b/src/shoot.c
@@ -371,29 +371,14 @@ static void do_this_every_second() // called every second
     }
     #endif
 
-// DIGIC 8+ uses different props
-#if !defined(CONFIG_DIGIC_VIII)
-#if defined(CONFIG_750D)
-    /* always update lens info, cam does not do it on LV on its own */
-    if (lens_info.lens_exists)
-    {
-        _prop_lv_lens_request_update();
-    }
-#elif defined(CONFIG_200D)
-    /* There's evproc that updates LV_LENS while outside LV
-     * No solution for LV yet */
-    if (!lv && lens_info.lens_exists)
-    {
-        call("msub.lensdata");
-    }
-#else
+    // DIGIC 8+ uses different props
+    #if defined(CONFIG_DIGIC_45) || defined(CONFIG_DIGIC_VI) || defined(CONFIG_DIGIC_VII)
     /* update lens info outside LiveView */
     if (!lv && lens_info.lens_exists)
     {
         _prop_lv_lens_request_update();
     }
-#endif
-#endif
+    #endif
 }
 
 // called every 200ms or on request

--- a/src/shoot.c
+++ b/src/shoot.c
@@ -371,6 +371,8 @@ static void do_this_every_second() // called every second
     }
     #endif
 
+// DIGIC 8+ uses different props
+#if !defined(CONFIG_DIGIC_VIII)
 #if defined(CONFIG_750D)
     /* always update lens info, cam does not do it on LV on its own */
     if (lens_info.lens_exists)
@@ -390,6 +392,7 @@ static void do_this_every_second() // called every second
     {
         _prop_lv_lens_request_update();
     }
+#endif
 #endif
 }
 

--- a/src/zebra-5dc.c
+++ b/src/zebra-5dc.c
@@ -223,7 +223,7 @@ void crop_set_dirty(int value)
     crop_dirty = MAX(crop_dirty, value);
 }
 
-PROP_HANDLER(PROP_HOUTPUT_TYPE)
+PROP_HANDLER(PROP_LV_OUTPUT_TYPE)
 {
     extern int ml_started;
     if (ml_started) redraw();

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -385,7 +385,7 @@ uint8_t* get_bvram_mirror() { return bvram_mirror; }
 
 #include "cropmarks.c"
 
-PROP_HANDLER(PROP_HOUTPUT_TYPE)
+PROP_HANDLER(PROP_LV_OUTPUT_TYPE)
 {
     extern int ml_started;
     if (ml_started) redraw();
@@ -409,8 +409,17 @@ int get_global_draw() // menu setting, or off if
 {
 #ifdef FEATURE_GLOBAL_DRAW
     
-    #ifdef LV_DISP_MODE
-        lv_disp_mode = LV_DISP_MODE;
+    #ifdef LV_OVERLAYS_MODE
+        /* kitor: As checked on R180:
+         *    0x0 - 1st overlays mode in LV (top+bottom)
+         *    0x1 - above + sides
+         *    0x2 - above + level
+         *    0x3 - clean overlays
+         *    0x6 - OlcApp? The screen like outside LV on DSLR
+         * EOSM and 5D2 already used this value in the past, and it was also "3"
+         * for clean overalys.
+         */
+        lv_disp_mode = LV_OVERLAYS_MODE != 3;
     #endif
 
     extern int ml_started;

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -4255,6 +4255,9 @@ static void loprio_sleep()
     while (is_mvr_buffer_almost_full()) msleep(100);
 }
 
+#if defined(LV_OVERLAYS_MODE) && defined(CONFIG_COMPOSITOR_DEDICATED_LAYER)
+uint32_t last_lv_overlays_mode = 0;
+#endif
 // Items which do not need a high FPS, but are CPU intensive
 // histogram, waveform...
 static void
@@ -4263,6 +4266,20 @@ livev_lopriority_task( void* unused )
     msleep(500);
     TASK_LOOP
     {
+        #if defined(LV_OVERLAYS_MODE) && defined(CONFIG_COMPOSITOR_DEDICATED_LAYER)
+        // Monitor overlays mode and clear screen if needed
+        // Existing code counts on Canon to overdraw screen.
+        if( (last_lv_overlays_mode == 3) &&
+            (LV_OVERLAYS_MODE != last_lv_overlays_mode ) &&
+            liveview_display_idle() )
+        {
+            //DryosDebugMsg(0, 15, "clear overlay %d", LV_OVERLAYS_MODE);
+            clrscr();
+        }
+        // update last overlays state
+        last_lv_overlays_mode = LV_OVERLAYS_MODE;
+        #endif
+
         #ifdef FEATURE_CROPMARKS
         #ifdef FEATURE_GHOST_IMAGE
         if (transparent_overlay_flag)


### PR DESCRIPTION
Addresses many issues from #30 and more.

Needed changes:
Models added in meantime require `LiveViewApp_dialog` stub (data pointer). Easy to find, just check where return pointer from `CreateDialogBox()` for `LiveViewApp_handler` is saved. On other models I already prepared (but commented out) `*_dialog` pointers for other apps we will need in future - but those are not needed right now.

For Digic 8 models with XCM and more than one Canon layer it is worth enabling `CONFIG_COMPOSITOR_XCM` (requires `XCM_GetSourceSurface()` and `_pXCM` stubs). This eliminates race condition on boot where regular code can get pointer to wrong (focus overlays) layer, making our rendering broken (invisible).