### PR TITLE
tasks.c: CONFIG_EOSRP -> CONFIG_RP

### DIFF
--- a/src/tasks.c
+++ b/src/tasks.c
@@ -351,7 +351,7 @@ MENU_UPDATE_FUNC(tasks_print)
 
 static void ml_shutdown()
 {
-#ifdef CONFIG_EOSRP
+#ifdef CONFIG_RP
     // FIXME: this should be promoted to a FEATURE flag,
     // or the shutter close feature should be directly
     // added here, or both:


### PR DESCRIPTION
On the model rename from EOSRP to RP a #define in tasks.c has been overlooked which makes the experimental feature "Close shutter on power off" not working. This PR fixes that.