### PR TITLE
RP.160: enable CHDK PTP commands

### DIFF
--- a/platform/RP.160/Makefile.platform.default
+++ b/platform/RP.160/Makefile.platform.default
@@ -23,4 +23,4 @@ PLATFORM_ARCH = armv7-a
 #endif
 
 ML_BOOT_OBJ     = boot-d678.o
-ML_SRC_EXTRA_OBJS += function_overrides.o test_features.o
+ML_SRC_EXTRA_OBJS += function_overrides.o test_features.o ptp.o ptp-chdk.o

--- a/platform/RP.160/stubs.S
+++ b/platform/RP.160/stubs.S
@@ -57,6 +57,8 @@ THUMB_FN(0xE006C3B8,  vsnprintf)                       // prints "!!! ERROR !!!\
 // Tier 1
 //*************************************************************************************************************
 
+THUMB_FN(0xE067E696,  ptp_register_handler)
+
 /** Interrupts **/
 // THUMB_FN(0xE01F3584,  cli_spin_lock)                   /* used in AllocateMemory/FreeMemory and others */
 // DATA_PTR(   0x287FC,  isr_table_handler)               /* from interrupt handler; address of the ISR handler */


### PR DESCRIPTION
This PR enables CHDK PTP commands for RP.160. This allows interacting with the camera via `ptpcam` tool. The following CHDK commands were testes successfully yet:

- download
- upload
- m (read memory)

All other commands are untested and not recommended to be used, once they have verified to work.