### PR TITLE
Python3 support

### DIFF
--- a/Makefile.user.default
+++ b/Makefile.user.default
@@ -176,7 +176,7 @@ CCACHE=ccache
 GREP=grep
 MV=mv
 AWK=awk
-PYTHON=python2
+PYTHON=python3
 PYTHON3=python3
 RST2LATEX=rst2latex.py
 

--- a/modules/align_string_proportional.py
+++ b/modules/align_string_proportional.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # http://code.activestate.com/recipes/577946-word-wrap-for-proportional-fonts/
 # MIT license
 
@@ -25,7 +25,7 @@ def word_wrap(text, width, extent_func):
         tokens.append('')
         widths = [sum(lookup[c] for c in token) for token in tokens]
         start, total = 0, 0
-        for index in xrange(0, len(tokens), 2):
+        for index in range(0, len(tokens), 2):
             if total + widths[index] > width:
                 end = index + 2 if index == start else index
                 lines.append(''.join(tokens[start:end]))
@@ -55,4 +55,4 @@ if __name__ == '__main__':
     # wrap to 80 columns
     lines = word_wrap(text, 80, extent_func)
     for line in lines:
-        print line
+        print(line)

--- a/modules/html2text.py
+++ b/modules/html2text.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """html2text: Turn HTML into equivalent Markdown-structured text."""
-__version__ = "3.1"
+__version__ = "3.200.3"
 __author__ = "Aaron Swartz (me@aaronsw.com)"
 __copyright__ = "(C) 2004-2008 Aaron Swartz. GNU GPL 3."
 __contributors__ = ["Martin 'Joey' Schulze", "Ricardo Reyes", "Kevin Jay North"]
@@ -32,19 +32,14 @@ except:
     import urllib
 import optparse, re, sys, codecs, types
 
-#try: from textwrap import wrap
-#except: pass
-
-#from align_string import align_paragraph
-#wrap = align_paragraph
-
-from align_string_proportional import word_wrap
-from rbf_read import extent_func, rbf_init_font
-rbf_init_font("../../data/fonts/argnor23.rbf")
-wrap = lambda text, width: word_wrap(text, width, extent_func)
+try: from textwrap import wrap
+except: pass
 
 # Use Unicode characters instead of their ascii psuedo-replacements
 UNICODE_SNOB = 0
+
+# Escape all special characters.  Output is less readable, but avoids corner case formatting issues.
+ESCAPE_SNOB = 0
 
 # Put the links after each paragraph instead of at the end.
 LINKS_EACH_PARAGRAPH = 0
@@ -62,8 +57,9 @@ INLINE_LINKS = True
 # Number of pixels Google indents nested lists
 GOOGLE_LIST_INDENT = 36
 
-IGNORE_ANCHORS = True
+IGNORE_ANCHORS = False
 IGNORE_IMAGES = False
+IGNORE_EMPHASIS = False
 
 ### Entity Nonsense ###
 
@@ -76,13 +72,13 @@ def name2cp(k):
         if k.startswith("&#") and k.endswith(";"): return int(k[2:-1]) # not in latin-1
         return ord(codecs.latin_1_decode(k)[0])
 
-unifiable = {'rsquo':"'", 'lsquo':"'", 'rdquo':'"', 'ldquo':'"', 
+unifiable = {'rsquo':"'", 'lsquo':"'", 'rdquo':'"', 'ldquo':'"',
 'copy':'(C)', 'mdash':'--', 'nbsp':' ', 'rarr':'->', 'larr':'<-', 'middot':'*',
 'ndash':'-', 'oelig':'oe', 'aelig':'ae',
-'agrave':'a', 'aacute':'a', 'acirc':'a', 'atilde':'a', 'auml':'a', 'aring':'a', 
-'egrave':'e', 'eacute':'e', 'ecirc':'e', 'euml':'e', 
+'agrave':'a', 'aacute':'a', 'acirc':'a', 'atilde':'a', 'auml':'a', 'aring':'a',
+'egrave':'e', 'eacute':'e', 'ecirc':'e', 'euml':'e',
 'igrave':'i', 'iacute':'i', 'icirc':'i', 'iuml':'i',
-'ograve':'o', 'oacute':'o', 'ocirc':'o', 'otilde':'o', 'ouml':'o', 
+'ograve':'o', 'oacute':'o', 'ocirc':'o', 'otilde':'o', 'ouml':'o',
 'ugrave':'u', 'uacute':'u', 'ucirc':'u', 'uuml':'u',
 'lrm':'', 'rlm':''}
 
@@ -90,42 +86,6 @@ unifiable_n = {}
 
 for k in unifiable.keys():
     unifiable_n[name2cp(k)] = unifiable[k]
-
-def charref(name):
-    if name[0] in ['x','X']:
-        c = int(name[1:], 16)
-    else:
-        c = int(name)
-    
-    if not UNICODE_SNOB and c in unifiable_n.keys():
-        return unifiable_n[c]
-    else:
-        try:
-            return unichr(c)
-        except NameError: #Python3
-            return chr(c)
-
-def entityref(c):
-    if not UNICODE_SNOB and c in unifiable.keys():
-        return unifiable[c]
-    else:
-        try: name2cp(c)
-        except KeyError: return "&" + c + ';'
-        else:
-            try:
-                return unichr(name2cp(c))
-            except NameError: #Python3
-                return chr(name2cp(c))
-
-def replaceEntities(s):
-    s = s.group(1)
-    if s[0] == "#": 
-        return charref(s[1:])
-    else: return entityref(s)
-
-r_unescape = re.compile(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));")
-def unescape(s):
-    return r_unescape.sub(replaceEntities, s)
 
 ### End Entity Nonsense ###
 
@@ -135,38 +95,6 @@ def onlywhite(line):
         if c is not ' ' and c is not '  ':
             return c is ' '
     return line
-
-def optwrap(text):
-    """Wrap all paragraphs in the provided text."""
-    if not BODY_WIDTH:
-        return text
-    
-    assert wrap, "Requires Python 2.3."
-    result = ''
-    newlines = 0
-    for para in text.split("\n"):
-        if len(para) > 0:
-            if para[0] != ' ' and para[0] != '-' and para[0] != '*':
-                for line in wrap(str(para), BODY_WIDTH):
-                    result += line + "\n"
-                result += "\n"
-                newlines = 2
-            else:
-                if not onlywhite(para):
-                    prefix = ""
-                    while len(para) and para[0] in " -*":
-                        prefix = para[0] + prefix
-                        para = para[1:]
-                    
-                    for line in wrap(str(para), BODY_WIDTH - len(prefix)):
-                        result += prefix + line + "\n"
-                        prefix = " " * len(prefix)
-                    newlines = 1
-        else:
-            if newlines < 2:
-                result += "\n"
-                newlines += 1
-    return result
 
 def hn(tag):
     if tag[0] == 'h' and len(tag) == 2:
@@ -182,6 +110,7 @@ def dumb_property_dict(style):
 def dumb_css_parser(data):
     """returns a hash of css selectors, each of which contains a hash of css attributes"""
     # remove @import sentences
+    data += ';'
     importIndex = data.find('@import')
     while importIndex != -1:
         data = data[0:importIndex] + data[data.find(';', importIndex) + 1:]
@@ -189,7 +118,10 @@ def dumb_css_parser(data):
 
     # parse the css. reverted from dictionary compehension in order to support older pythons
     elements =  [x.split('{') for x in data.split('}') if '{' in x.strip()]
-    elements = dict([(a.strip(), dumb_property_dict(b)) for a, b in elements])
+    try:
+        elements = dict([(a.strip(), dumb_property_dict(b)) for a, b in elements])
+    except ValueError:
+        elements = {} # not that important
 
     return elements
 
@@ -212,13 +144,6 @@ def google_list_style(style):
         if list_style in ['disc', 'circle', 'square', 'none']:
             return 'ul'
     return 'ol'
-
-def google_nest_count(style):
-    """calculate the nesting count of google doc lists"""
-    nest_count = 0
-    if 'margin-left' in style:
-        nest_count = int(style['margin-left'][:-2]) / GOOGLE_LIST_INDENT
-    return nest_count
 
 def google_has_height(style):
     """check if the style of the element has the 'height' attribute explicitly defined"""
@@ -253,24 +178,47 @@ def list_numbering_start(attrs):
     else:
         return 0
 
-class _html2text(HTMLParser.HTMLParser):
+class HTML2Text(HTMLParser.HTMLParser):
     def __init__(self, out=None, baseurl=''):
         HTMLParser.HTMLParser.__init__(self)
-        
-        if out is None: self.out = self.outtextf
-        else: self.out = out
-        self.outtextlist = [] # empty list to store output characters before they are  "joined"
+
+        # Config options
+        self.unicode_snob = UNICODE_SNOB
+        self.escape_snob = ESCAPE_SNOB
+        self.links_each_paragraph = LINKS_EACH_PARAGRAPH
+        self.body_width = BODY_WIDTH
+        self.skip_internal_links = SKIP_INTERNAL_LINKS
+        self.inline_links = INLINE_LINKS
+        self.google_list_indent = GOOGLE_LIST_INDENT
+        self.ignore_links = IGNORE_ANCHORS
+        self.ignore_images = IGNORE_IMAGES
+        self.ignore_emphasis = IGNORE_EMPHASIS
+        self.google_doc = False
+        self.ul_item_mark = '*'
+        self.emphasis_mark = '_'
+        self.strong_mark = '**'
+
+        if out is None:
+            self.out = self.outtextf
+        else:
+            self.out = out
+
+        self.outtextlist = []  # empty list to store output characters before they are "joined"
+
         try:
             self.outtext = unicode()
-        except NameError: # Python3
+        except NameError:  # Python3
             self.outtext = str()
+
         self.quiet = 0
-        self.p_p = 0 # number of newline character to print before next output
+        self.p_p = 0  # number of newline character to print before next output
         self.outcount = 0
         self.start = 1
         self.space = 0
         self.a = []
         self.astack = []
+        self.maybe_automatic_link = None
+        self.absolute_url_matcher = re.compile(r'^[a-zA-Z+]+://')
         self.acount = 0
         self.list = []
         self.blockquote = 0
@@ -286,61 +234,69 @@ class _html2text(HTMLParser.HTMLParser):
         self.emphasis = 0
         self.drop_white_space = 0
         self.inheader = False
-        self.abbr_title = None # current abbreviation definition
-        self.abbr_data = None # last inner HTML (for abbr being defined)
-        self.abbr_list = {} # stack of abbreviations to write later
+        self.abbr_title = None  # current abbreviation definition
+        self.abbr_data = None  # last inner HTML (for abbr being defined)
+        self.abbr_list = {}  # stack of abbreviations to write later
         self.baseurl = baseurl
 
-        if options.google_doc:
-            del unifiable_n[name2cp('nbsp')]
-            unifiable['nbsp'] = '&nbsp_place_holder;'
-    
+        try: del unifiable_n[name2cp('nbsp')]
+        except KeyError: pass
+        unifiable['nbsp'] = '&nbsp_place_holder;'
+
+
     def feed(self, data):
         data = data.replace("</' + 'script>", "</ignore>")
         HTMLParser.HTMLParser.feed(self, data)
-    
-    def outtextf(self, s): 
+
+    def handle(self, data):
+        self.feed(data)
+        self.feed("")
+        return self.optwrap(self.close())
+
+    def outtextf(self, s):
         self.outtextlist.append(s)
         if s: self.lastWasNL = s[-1] == '\n'
-    
+
     def close(self):
         HTMLParser.HTMLParser.close(self)
-        
+
         self.pbr()
         self.o('', 0, 'end')
 
         self.outtext = self.outtext.join(self.outtextlist)
-        
-        if options.google_doc:
-            self.outtext = self.outtext.replace('&nbsp_place_holder;', ' ');
-        
+        if self.unicode_snob:
+            nbsp = unichr(name2cp('nbsp'))
+        else:
+            nbsp = u' '
+        self.outtext = self.outtext.replace(u'&nbsp_place_holder;', nbsp)
+
         return self.outtext
-        
+
     def handle_charref(self, c):
-        self.o(charref(c), 1)
+        self.o(self.charref(c), 1)
 
     def handle_entityref(self, c):
-        self.o(entityref(c), 1)
-            
+        self.o(self.entityref(c), 1)
+
     def handle_starttag(self, tag, attrs):
         self.handle_tag(tag, attrs, 1)
-    
+
     def handle_endtag(self, tag):
         self.handle_tag(tag, None, 0)
-        
+
     def previousIndex(self, attrs):
         """ returns the index of certain set of attributes (of a link) in the
             self.a list
- 
+
             If the set of attributes is not found, returns None
         """
         if not has_key(attrs, 'href'): return None
-        
+
         i = -1
         for a in self.a:
             i += 1
             match = 0
-            
+
             if has_key(a, 'href') and a['href'] == attrs['href']:
                 if has_key(a, 'title') or has_key(attrs, 'title'):
                         if (has_key(a, 'title') and has_key(attrs, 'title') and
@@ -354,14 +310,14 @@ class _html2text(HTMLParser.HTMLParser):
     def drop_last(self, nLetters):
         if not self.quiet:
             self.outtext = self.outtext[:-nLetters]
-           
+
     def handle_emphasis(self, start, tag_style, parent_style):
         """handles various text emphases"""
         tag_emphasis = google_text_emphasis(tag_style)
         parent_emphasis = google_text_emphasis(parent_style)
 
         # handle Google's text emphasis
-        strikethrough =  'line-through' in tag_emphasis and options.hide_strikethrough
+        strikethrough =  'line-through' in tag_emphasis and self.hide_strikethrough
         bold = 'bold' in tag_emphasis and not 'bold' in parent_emphasis
         italic = 'italic' in tag_emphasis and not 'italic' in parent_emphasis
         fixed = google_fixed_width_font(tag_style) and not \
@@ -375,10 +331,10 @@ class _html2text(HTMLParser.HTMLParser):
             if strikethrough:
                 self.quiet += 1
             if italic:
-                self.o("_")
+                self.o(self.emphasis_mark)
                 self.drop_white_space += 1
             if bold:
-                self.o("**")
+                self.o(self.strong_mark)
                 self.drop_white_space += 1
             if fixed:
                 self.o('`')
@@ -404,14 +360,14 @@ class _html2text(HTMLParser.HTMLParser):
                     self.drop_last(2)
                     self.drop_white_space -= 1
                 else:
-                    self.o("**")
+                    self.o(self.strong_mark)
             if italic:
                 if self.drop_white_space:
                     # empty emphasis, drop it
                     self.drop_last(1)
                     self.drop_white_space -= 1
                 else:
-                    self.o("_")
+                    self.o(self.emphasis_mark)
             # space is only allowed after *all* emphasis marks
             if (bold or italic) and not self.emphasis:
                     self.o(" ")
@@ -425,7 +381,7 @@ class _html2text(HTMLParser.HTMLParser):
         else:
             attrs = dict(attrs)
 
-        if options.google_doc:
+        if self.google_doc:
             # the attrs parameter is empty for a closing tag. in addition, we
             # need the attributes of the parent nodes in order to get a
             # complete style description for the current element. we assume
@@ -451,14 +407,14 @@ class _html2text(HTMLParser.HTMLParser):
                 return # prevent redundant emphasis marks on headers
 
         if tag in ['p', 'div']:
-            if options.google_doc:
+            if self.google_doc:
                 if start and google_has_height(tag_style):
                     self.p()
                 else:
                     self.soft_br()
             else:
                 self.p()
-        
+
         if tag == "br" and start: self.o("  \n")
 
         if tag == "hr" and start:
@@ -466,7 +422,7 @@ class _html2text(HTMLParser.HTMLParser):
             self.o("* * *")
             self.p()
 
-        if tag in ["head", "style", 'script']: 
+        if tag in ["head", "style", 'script']:
             if start: self.quiet += 1
             else: self.quiet -= 1
 
@@ -476,29 +432,29 @@ class _html2text(HTMLParser.HTMLParser):
 
         if tag in ["body"]:
             self.quiet = 0 # sites like 9rules.com never close <head>
-        
+
         if tag == "blockquote":
-            if start: 
+            if start:
                 self.p(); self.o('> ', 0, 1); self.start = 1
                 self.blockquote += 1
             else:
                 self.blockquote -= 1
                 self.p()
-        
-        if tag in ['em', 'i', 'u']: self.o("_")
-        if tag in ['strong', 'b']: self.o("**")
-        if tag in ['del', 'strike']:
-            if start:                                                           
+
+        if tag in ['em', 'i', 'u'] and not self.ignore_emphasis: self.o(self.emphasis_mark)
+        if tag in ['strong', 'b'] and not self.ignore_emphasis: self.o(self.strong_mark)
+        if tag in ['del', 'strike', 's']:
+            if start:
                 self.o("<"+tag+">")
             else:
                 self.o("</"+tag+">")
 
-        if options.google_doc:
+        if self.google_doc:
             if not self.inheader:
                 # handle some font attributes, but leave headers clean
                 self.handle_emphasis(start, tag_style, parent_style)
 
-        if tag == "code" and not self.pre: self.o('`') #TODO: `` `this` ``
+        if tag in ["code", "tt"] and not self.pre: self.o('`') #TODO: `` `this` ``
         if tag == "abbr":
             if start:
                 self.abbr_title = None
@@ -510,20 +466,22 @@ class _html2text(HTMLParser.HTMLParser):
                     self.abbr_list[self.abbr_data] = self.abbr_title
                     self.abbr_title = None
                 self.abbr_data = ''
-        
-        if tag == "a" and not IGNORE_ANCHORS:
+
+        if tag == "a" and not self.ignore_links:
             if start:
-                if has_key(attrs, 'href') and not (SKIP_INTERNAL_LINKS and attrs['href'].startswith('#')): 
+                if has_key(attrs, 'href') and not (self.skip_internal_links and attrs['href'].startswith('#')):
                     self.astack.append(attrs)
-                    self.o("[")
+                    self.maybe_automatic_link = attrs['href']
                 else:
                     self.astack.append(None)
             else:
                 if self.astack:
                     a = self.astack.pop()
-                    if a:
-                        if INLINE_LINKS:
-                            self.o("](" + a['href'] + ")")
+                    if self.maybe_automatic_link:
+                        self.maybe_automatic_link = None
+                    elif a:
+                        if self.inline_links:
+                            self.o("](" + escape_md(a['href']) + ")")
                         else:
                             i = self.previousIndex(a)
                             if i is not None:
@@ -534,15 +492,15 @@ class _html2text(HTMLParser.HTMLParser):
                                 a['outcount'] = self.outcount
                                 self.a.append(a)
                             self.o("][" + str(a['count']) + "]")
-        
-        if tag == "img" and start and not IGNORE_IMAGES:
+
+        if tag == "img" and start and not self.ignore_images:
             if has_key(attrs, 'src'):
                 attrs['href'] = attrs['src']
                 alt = attrs.get('alt', '')
-                if INLINE_LINKS:
-                    self.o("![")
-                    self.o(alt)
-                    self.o("]("+ attrs['href'] +")")
+                self.o("![" + escape_md(alt) + "]")
+
+                if self.inline_links:
+                    self.o("(" + escape_md(attrs['href']) + ")")
                 else:
                     i = self.previousIndex(attrs)
                     if i is not None:
@@ -552,21 +510,19 @@ class _html2text(HTMLParser.HTMLParser):
                         attrs['count'] = self.acount
                         attrs['outcount'] = self.outcount
                         self.a.append(attrs)
-                    self.o("![")
-                    self.o(alt)
-                    self.o("]["+ str(attrs['count']) +"]")
-        
+                    self.o("[" + str(attrs['count']) + "]")
+
         if tag == 'dl' and start: self.p()
         if tag == 'dt' and not start: self.pbr()
         if tag == 'dd' and start: self.o('    ')
         if tag == 'dd' and not start: self.pbr()
-        
+
         if tag in ["ol", "ul"]:
             # Google Docs create sub lists as top level lists
             if (not self.list) and (not self.lastWasList):
                 self.p()
             if start:
-                if options.google_doc:
+                if self.google_doc:
                     list_style = google_list_style(tag_style)
                 else:
                     list_style = tag
@@ -577,26 +533,26 @@ class _html2text(HTMLParser.HTMLParser):
             self.lastWasList = True
         else:
             self.lastWasList = False
-        
+
         if tag == 'li':
             self.pbr()
             if start:
                 if self.list: li = self.list[-1]
                 else: li = {'name':'ul', 'num':0}
-                if options.google_doc:
-                    nest_count = google_nest_count(tag_style)
+                if self.google_doc:
+                    nest_count = self.google_nest_count(tag_style)
                 else:
                     nest_count = len(self.list)
                 self.o("  " * nest_count) #TODO: line up <ol><li>s > 9 correctly.
-                if li['name'] == "ul": self.o(options.ul_item_mark + " ")
+                if li['name'] == "ul": self.o(self.ul_item_mark + " ")
                 elif li['name'] == "ol":
                     li['num'] += 1
                     self.o(str(li['num'])+". ")
                 self.start = 1
-        
+
         if tag in ["table", "tr"] and start: self.p()
         if tag == 'td': self.pbr()
-        
+
         if tag == "pre":
             if start:
                 self.startpre = 1
@@ -604,28 +560,31 @@ class _html2text(HTMLParser.HTMLParser):
             else:
                 self.pre = 0
             self.p()
-            
-    def pbr(self):
-        if self.p_p == 0: self.p_p = 1
 
-    def p(self): self.p_p = 2
+    def pbr(self):
+        if self.p_p == 0:
+            self.p_p = 1
+
+    def p(self):
+        self.p_p = 2
 
     def soft_br(self):
         self.pbr()
         self.br_toggle = '  '
-    
+
     def o(self, data, puredata=0, force=0):
-        if self.abbr_data is not None: self.abbr_data += data
-        
-        if not self.quiet: 
-            if options.google_doc:
+        if self.abbr_data is not None:
+            self.abbr_data += data
+
+        if not self.quiet:
+            if self.google_doc:
                 # prevent white space immediately after 'begin emphasis' marks ('**' and '_')
                 lstripped_data = data.lstrip()
                 if self.drop_white_space and not (self.pre or self.code):
                     data = lstripped_data
                 if lstripped_data != '':
                     self.drop_white_space = 0
-            
+
             if puredata and not self.pre:
                 data = re.sub('\s+', ' ', data)
                 if data and data[0] == ' ':
@@ -635,15 +594,25 @@ class _html2text(HTMLParser.HTMLParser):
 
             if self.startpre:
                 #self.out(" :") #TODO: not output when already one there
-                self.startpre = 0
-            
+                if not data.startswith("\n"):  # <pre>stuff...
+                    data = "\n" + data
+
             bq = (">" * self.blockquote)
             if not (force and data and data[0] == ">") and self.blockquote: bq += " "
-            
+
             if self.pre:
-                bq += "    "
+                if not self.list:
+                    bq += "    "
+                #else: list content is already partially indented
+                for i in xrange(len(self.list)):
+                    bq += "    "
                 data = data.replace("\n", "\n"+bq)
-            
+
+            if self.startpre:
+                self.startpre = 0
+                if self.list:
+                    data = data.lstrip("\n") # use existing initial indentation
+
             if self.start:
                 self.space = 0
                 self.p_p = 0
@@ -659,18 +628,18 @@ class _html2text(HTMLParser.HTMLParser):
                 self.out((self.br_toggle+'\n'+bq)*self.p_p)
                 self.space = 0
                 self.br_toggle = ''
-                
+
             if self.space:
                 if not self.lastWasNL: self.out(' ')
                 self.space = 0
 
-            if self.a and ((self.p_p == 2 and LINKS_EACH_PARAGRAPH) or force == "end"):
+            if self.a and ((self.p_p == 2 and self.links_each_paragraph) or force == "end"):
                 if force == "end": self.out("\n")
 
                 newa = []
                 for link in self.a:
                     if self.outcount > link['outcount']:
-                        self.out("   ["+ str(link['count']) +"]: " + urlparse.urljoin(self.baseurl, link['href'])) 
+                        self.out("   ["+ str(link['count']) +"]: " + urlparse.urljoin(self.baseurl, link['href']))
                         if has_key(link, 'title'): self.out(" ("+link['title']+")")
                         self.out("\n")
                     else:
@@ -679,7 +648,7 @@ class _html2text(HTMLParser.HTMLParser):
                 if self.a != newa: self.out("\n") # Don't need an extra line when nothing was done.
 
                 self.a = newa
-            
+
             if self.abbr_list and force == "end":
                 for abbr, definition in self.abbr_list.items():
                     self.out("  *[" + abbr + "]: " + definition + "\n")
@@ -694,9 +663,142 @@ class _html2text(HTMLParser.HTMLParser):
         if self.style:
             self.style_def.update(dumb_css_parser(data))
 
+        if not self.maybe_automatic_link is None:
+            href = self.maybe_automatic_link
+            if href == data and self.absolute_url_matcher.match(href):
+                self.o("<" + data + ">")
+                return
+            else:
+                self.o("[")
+                self.maybe_automatic_link = None
+
+        if not self.code and not self.pre:
+            data = escape_md_section(data, snob=self.escape_snob)
         self.o(data, 1)
-    
+
     def unknown_decl(self, data): pass
+
+    def charref(self, name):
+        if name[0] in ['x','X']:
+            c = int(name[1:], 16)
+        else:
+            c = int(name)
+
+        if not self.unicode_snob and c in unifiable_n.keys():
+            return unifiable_n[c]
+        else:
+            try:
+                return unichr(c)
+            except NameError: #Python3
+                return chr(c)
+
+    def entityref(self, c):
+        if not self.unicode_snob and c in unifiable.keys():
+            return unifiable[c]
+        else:
+            try: name2cp(c)
+            except KeyError: return "&" + c + ';'
+            else:
+                try:
+                    return unichr(name2cp(c))
+                except NameError: #Python3
+                    return chr(name2cp(c))
+
+    def replaceEntities(self, s):
+        s = s.group(1)
+        if s[0] == "#":
+            return self.charref(s[1:])
+        else: return self.entityref(s)
+
+    r_unescape = re.compile(r"&(#?[xX]?(?:[0-9a-fA-F]+|\w{1,8}));")
+    def unescape(self, s):
+        return self.r_unescape.sub(self.replaceEntities, s)
+
+    def google_nest_count(self, style):
+        """calculate the nesting count of google doc lists"""
+        nest_count = 0
+        if 'margin-left' in style:
+            nest_count = int(style['margin-left'][:-2]) / self.google_list_indent
+        return nest_count
+
+
+    def optwrap(self, text):
+        """Wrap all paragraphs in the provided text."""
+        if not self.body_width:
+            return text
+
+        assert wrap, "Requires Python 2.3."
+        result = ''
+        newlines = 0
+        for para in text.split("\n"):
+            if len(para) > 0:
+                if not skipwrap(para):
+                    result += "\n".join(wrap(para, self.body_width))
+                    if para.endswith('  '):
+                        result += "  \n"
+                        newlines = 1
+                    else:
+                        result += "\n\n"
+                        newlines = 2
+                else:
+                    if not onlywhite(para):
+                        result += para + "\n"
+                        newlines = 1
+            else:
+                if newlines < 2:
+                    result += "\n"
+                    newlines += 1
+        return result
+
+ordered_list_matcher = re.compile(r'\d+\.\s')
+unordered_list_matcher = re.compile(r'[-\*\+]\s')
+md_chars_matcher = re.compile(r"([\\\[\]\(\)])")
+md_chars_matcher_all = re.compile(r"([`\*_{}\[\]\(\)#!])")
+md_dot_matcher = re.compile(r"""
+    ^             # start of line
+    (\s*\d+)      # optional whitespace and a number
+    (\.)          # dot
+    (?=\s)        # lookahead assert whitespace
+    """, re.MULTILINE | re.VERBOSE)
+md_plus_matcher = re.compile(r"""
+    ^
+    (\s*)
+    (\+)
+    (?=\s)
+    """, flags=re.MULTILINE | re.VERBOSE)
+md_dash_matcher = re.compile(r"""
+    ^
+    (\s*)
+    (-)
+    (?=\s|\-)     # followed by whitespace (bullet list, or spaced out hr)
+                  # or another dash (header or hr)
+    """, flags=re.MULTILINE | re.VERBOSE)
+slash_chars = r'\`*_{}[]()#+-.!'
+md_backslash_matcher = re.compile(r'''
+    (\\)          # match one slash
+    (?=[%s])      # followed by a char that requires escaping
+    ''' % re.escape(slash_chars),
+    flags=re.VERBOSE)
+
+def skipwrap(para):
+    # If the text begins with four spaces or one tab, it's a code block; don't wrap
+    if para[0:4] == '    ' or para[0] == '\t':
+        return True
+    # If the text begins with only two "--", possibly preceded by whitespace, that's
+    # an emdash; so wrap.
+    stripped = para.lstrip()
+    if stripped[0:2] == "--" and len(stripped) > 2 and stripped[2] != "-":
+        return False
+    # I'm not sure what this is for; I thought it was to detect lists, but there's
+    # a <br>-inside-<span> case in one of the tests that also depends upon it.
+    if stripped[0:1] == '-' or stripped[0:1] == '*':
+        return True
+    # If the text begins with a single -, *, or +, followed by a space, or an integer,
+    # followed by a ., followed by a space (in either case optionally preceeded by
+    # whitespace), it's a list; don't wrap.
+    if ordered_list_matcher.match(stripped) or unordered_list_matcher.match(stripped):
+        return True
+    return False
 
 def wrapwrite(text):
     text = text.encode('utf-8')
@@ -705,50 +807,61 @@ def wrapwrite(text):
     except AttributeError:
         sys.stdout.write(text)
 
-def html2text_file(html, out=wrapwrite, baseurl=''):
-    h = _html2text(out, baseurl)
-    h.feed(html)
-    h.feed("")
-    return h.close()
-
 def html2text(html, baseurl=''):
-    return optwrap(html2text_file(html, None, baseurl))
+    h = HTML2Text(baseurl=baseurl)
+    return h.handle(html)
 
-class Storage: pass
-options = Storage()
-options.google_doc = False
-options.ul_item_mark = '*'
+def unescape(s, unicode_snob=False):
+    h = HTML2Text()
+    h.unicode_snob = unicode_snob
+    return h.unescape(s)
 
-if __name__ == "__main__":
+def escape_md(text):
+    """Escapes markdown-sensitive characters within other markdown constructs."""
+    return md_chars_matcher.sub(r"\\\1", text)
+
+def escape_md_section(text, snob=False):
+    """Escapes markdown-sensitive characters across whole document sections."""
+    text = md_backslash_matcher.sub(r"\\\1", text)
+    if snob:
+        text = md_chars_matcher_all.sub(r"\\\1", text)
+    text = md_dot_matcher.sub(r"\1\\\2", text)
+    text = md_plus_matcher.sub(r"\1\\\2", text)
+    text = md_dash_matcher.sub(r"\1\\\2", text)
+    return text
+
+
+def main():
     baseurl = ''
-    
+
     p = optparse.OptionParser('%prog [(filename|url) [encoding]]',
                               version='%prog ' + __version__)
+    p.add_option("--ignore-emphasis", dest="ignore_emphasis", action="store_true",
+        default=IGNORE_EMPHASIS, help="don't include any formatting for emphasis")
+    p.add_option("--ignore-links", dest="ignore_links", action="store_true",
+        default=IGNORE_ANCHORS, help="don't include any formatting for links")
+    p.add_option("--ignore-images", dest="ignore_images", action="store_true",
+        default=IGNORE_IMAGES, help="don't include any formatting for images")
     p.add_option("-g", "--google-doc", action="store_true", dest="google_doc",
         default=False, help="convert an html-exported Google Document")
     p.add_option("-d", "--dash-unordered-list", action="store_true", dest="ul_style_dash",
         default=False, help="use a dash rather than a star for unordered list items")
+    p.add_option("-e", "--asterisk-emphasis", action="store_true", dest="em_style_asterisk",
+        default=False, help="use an asterisk rather than an underscore for emphasized text")
     p.add_option("-b", "--body-width", dest="body_width", action="store", type="int",
-        default=78, help="number of characters per output line, 0 for no wrap")
+        default=BODY_WIDTH, help="number of characters per output line, 0 for no wrap")
     p.add_option("-i", "--google-list-indent", dest="list_indent", action="store", type="int",
         default=GOOGLE_LIST_INDENT, help="number of pixels Google indents nested lists")
     p.add_option("-s", "--hide-strikethrough", action="store_true", dest="hide_strikethrough",
-        default=False, help="hide strike-through text. only relevent when -g is specified as well")
+        default=False, help="hide strike-through text. only relevant when -g is specified as well")
+    p.add_option("--escape-all", action="store_true", dest="escape_snob",
+        default=False, help="Escape all special characters.  Output is less readable, but avoids corner case formatting issues.")
     (options, args) = p.parse_args()
 
-    # handle options
-    if options.ul_style_dash:
-        options.ul_item_mark = '-'
-    else:
-        options.ul_item_mark = '*'
-
-    BODY_WIDTH = options.body_width
-    GOOGLE_LIST_INDENT = options.list_indent
-
     # process input
+    encoding = "utf-8"
     if len(args) > 0:
         file_ = args[0]
-        encoding = None
         if len(args) == 2:
             encoding = args[1]
         if len(args) > 2:
@@ -757,17 +870,15 @@ if __name__ == "__main__":
         if file_.startswith('http://') or file_.startswith('https://'):
             baseurl = file_
             j = urllib.urlopen(baseurl)
-            text = j.read()
+            data = j.read()
             if encoding is None:
                 try:
                     from feedparser import _getCharacterEncoding as enc
                 except ImportError:
                     enc = lambda x, y: ('utf-8', 1)
-                encoding = enc(j.headers, text)[0]
+                encoding = enc(j.headers, data)[0]
                 if encoding == 'us-ascii':
                     encoding = 'utf-8'
-            data = text.decode(encoding)
-
         else:
             data = open(file_, 'rb').read()
             if encoding is None:
@@ -776,7 +887,28 @@ if __name__ == "__main__":
                 except ImportError:
                     detect = lambda x: {'encoding': 'utf-8'}
                 encoding = detect(data)['encoding']
-            data = data.decode(encoding)
     else:
         data = sys.stdin.read()
-    wrapwrite(html2text(data, baseurl))
+
+    data = data.decode(encoding)
+    h = HTML2Text(baseurl=baseurl)
+    # handle options
+    if options.ul_style_dash: h.ul_item_mark = '-'
+    if options.em_style_asterisk:
+        h.emphasis_mark = '*'
+        h.strong_mark = '__'
+
+    h.body_width = options.body_width
+    h.list_indent = options.list_indent
+    h.ignore_emphasis = options.ignore_emphasis
+    h.ignore_links = options.ignore_links
+    h.ignore_images = options.ignore_images
+    h.google_doc = options.google_doc
+    h.hide_strikethrough = options.hide_strikethrough
+    h.escape_snob = options.escape_snob
+
+    wrapwrite(h.handle(data))
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/rbf_read.py
+++ b/modules/rbf_read.py
@@ -8,7 +8,7 @@ class Bunch:
 
 # RBF loading code from rbfEditor, rebUtils.py
 # http://freecode.com/projects/rbfeditor
-_FNT_HDR_MAGIC  = '\xE0\x0E\xF0\x0D\x03\x00\x00\x00'
+_FNT_HDR_MAGIC  = b'\xE0\x0E\xF0\x0D\x03\x00\x00\x00'
 _FNT_HDR_SIZE   = 0x74
 _FNT_MAX_NAME   = 64
 
@@ -43,7 +43,7 @@ def rbf_load(file):
         self.width = int(8 * self._charSize / self.height)
         self.charCount = self._charLast - self.charFirst + 1
 
-        charlist = xrange(0, self.charCount)
+        charlist = list(range(0, self.charCount))
         file.seek(self._wmapAddr)
         for char in charlist:
             self.wTable.append(struct.unpack('=B', file.read(1))[0])


### PR DESCRIPTION
This eliminates python2 as a dependency for building ML. Module info screens appear to be generating correctly, just as before (which is the primary purpose of the python build scripts). Tested on macos and 5D3.

Main changes:
- Python 3 syntax changes
- Set `PYTHON=python3` in Makefile.user.default
- Updated html2text to a later version, for python3 compatibility (https://github.com/aaronsw/html2text)

I also changed `readme2modulestrings` to call python modules directly, instead of using terminal commands and pipes.
- Calls html2text module directly now
- Calls the docutils module directly, instead of checking possible aliases for rst2html (a utility provided by the docutils module anyway)
- Use re module for the regular expression part instead of grep
- No more pipes.

Still needed:
- Test on windows (make sure it works, confirm module info screens look correct)
- Test on linux
- Check if non-building-related python2 scripts need attention
- Clean things up, combine the `PYTHON` and `PYTHON3` variables in `Makefile.user.default`, etc...