### PR TITLE
Remove Python 2 dependency

### DIFF
--- a/Makefile.user.default
+++ b/Makefile.user.default
@@ -176,7 +176,7 @@ CCACHE=ccache
 GREP=grep
 MV=mv
 AWK=awk
-PYTHON=python2
+PYTHON=python3
 PYTHON3=python3
 RST2LATEX=rst2latex.py
 

--- a/modules/align_string.py
+++ b/modules/align_string.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 '''
 align_string.py
 
@@ -67,13 +67,13 @@ def align_paragraph(paragraph, width, debug=0):
     elif type(paragraph) == type(tuple()):
         lines.extend(list(paragraph))
     else:
-        raise TypeError, 'Unsopported paragraph type: %r' % type(paragraph)
+        raise TypeError('Unsopported paragraph type: %r' % type(paragraph))
 
     flatten_para = ' '.join(lines)
 
     splitted = textwrap.wrap(flatten_para, width) 
     if debug:
-        print 'textwrap:\n%s\n' % '\n'.join(splitted)
+        print('textwrap:\n%s\n' % '\n'.join(splitted))
 
     wrapped = list()
     while len(splitted) > 0:
@@ -86,7 +86,7 @@ def align_paragraph(paragraph, width, debug=0):
         wrapped.append(aligned)
 
     if debug:
-        print 'textwrap & align_string:\n%s\n' % '\n'.join(wrapped)
+        print('textwrap & align_string:\n%s\n' % '\n'.join(wrapped))
 
     return wrapped
 

--- a/modules/align_string_proportional.py
+++ b/modules/align_string_proportional.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # http://code.activestate.com/recipes/577946-word-wrap-for-proportional-fonts/
 # MIT license
 
@@ -25,7 +25,7 @@ def word_wrap(text, width, extent_func):
         tokens.append('')
         widths = [sum(lookup[c] for c in token) for token in tokens]
         start, total = 0, 0
-        for index in xrange(0, len(tokens), 2):
+        for index in range(0, len(tokens), 2):
             if total + widths[index] > width:
                 end = index + 2 if index == start else index
                 lines.append(''.join(tokens[start:end]))
@@ -55,4 +55,4 @@ if __name__ == '__main__':
     # wrap to 80 columns
     lines = word_wrap(text, 80, extent_func)
     for line in lines:
-        print line
+        print(line)

--- a/modules/html2text.py
+++ b/modules/html2text.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """html2text: Turn HTML into equivalent Markdown-structured text."""
 __version__ = "3.1"
 __author__ = "Aaron Swartz (me@aaronsw.com)"
@@ -132,8 +132,8 @@ def unescape(s):
 def onlywhite(line):
     """Return true if the line does only consist of whitespace characters."""
     for c in line:
-        if c is not ' ' and c is not '  ':
-            return c is ' '
+        if c != ' ' and c != '  ':
+            return c == ' '
     return line
 
 def optwrap(text):
@@ -217,7 +217,7 @@ def google_nest_count(style):
     """calculate the nesting count of google doc lists"""
     nest_count = 0
     if 'margin-left' in style:
-        nest_count = int(style['margin-left'][:-2]) / GOOGLE_LIST_INDENT
+        nest_count = int(style['margin-left'][:-2]) // GOOGLE_LIST_INDENT
     return nest_count
 
 def google_has_height(style):

--- a/modules/rbf_read.py
+++ b/modules/rbf_read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import struct, sys
 
 # from http://stackoverflow.com/questions/35988/c-like-structures-in-python
@@ -8,7 +8,7 @@ class Bunch:
 
 # RBF loading code from rbfEditor, rebUtils.py
 # http://freecode.com/projects/rbfeditor
-_FNT_HDR_MAGIC  = '\xE0\x0E\xF0\x0D\x03\x00\x00\x00'
+_FNT_HDR_MAGIC  = b'\xE0\x0E\xF0\x0D\x03\x00\x00\x00'
 _FNT_HDR_SIZE   = 0x74
 _FNT_MAX_NAME   = 64
 
@@ -40,10 +40,10 @@ def rbf_load(file):
         self.wTable     = []
         self.cTable     = []
 
-        self.width = int(8 * self._charSize / self.height)
+        self.width = int(8 * self._charSize // self.height)
         self.charCount = self._charLast - self.charFirst + 1
 
-        charlist = xrange(0, self.charCount)
+        charlist = list(range(0, self.charCount))
         file.seek(self._wmapAddr)
         for char in charlist:
             self.wTable.append(struct.unpack('=B', file.read(1))[0])

--- a/modules/readme2modulestrings.py
+++ b/modules/readme2modulestrings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # extract module strings from README.rst
 
 import sys, re
@@ -14,13 +14,13 @@ def run(cmd):
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out = p.communicate()
         if p.returncode or out[1]:
-            print >> sys.stderr, cmd
-            print >> sys.stderr, out[0]
-            print >> sys.stderr, out[1]
+            print(cmd, file=sys.stderr)
+            print(out[0].decode(), file=sys.stderr)
+            print(out[1].decode(), file=sys.stderr)
             exit(1)
-        return out[0]
+        return out[0].decode()
     except:
-        print >> sys.stderr, sys.exc_info()
+        print(sys.exc_info(), file=sys.stderr)
         exit(1)
 
 # see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=37506 for how to place some strings in a custom section
@@ -38,19 +38,19 @@ def c_repr(name):
 strings = []
 def add_string(name, value):
     a = chr(ord('a') + len(strings))
-    print "static char __module_string_%s_name [] MODULE_STRINGS_SECTION = %s;" % (a, c_repr(name))
-    print "static char __module_string_%s_value[] MODULE_STRINGS_SECTION = %s;" % (a, c_repr(value))
+    print("static char __module_string_%s_name [] MODULE_STRINGS_SECTION = %s;" % (a, c_repr(name)))
+    print("static char __module_string_%s_value[] MODULE_STRINGS_SECTION = %s;" % (a, c_repr(value)))
 
     strings.append((name, value))
 
 def declare_string_section():
-    print
-    print "#define MODULE_STRINGS() \\"
-    print('  MODULE_STRINGS_START() \\')
+    print("")
+    print("#define MODULE_STRINGS() \\")
+    print("  MODULE_STRINGS_START() \\")
     for i, s in enumerate(strings):
         a = chr(ord('a') + i)
-        print "    MODULE_STRING(__module_string_%s_name, __module_string_%s_value) \\" % (a, a)
-    print('  MODULE_STRINGS_END()')
+        print("    MODULE_STRING(__module_string_%s_name, __module_string_%s_value) \\" % (a, a))
+    print("  MODULE_STRINGS_END()")
     
 def is_command_available(name):
     """Check if command `name` is on PATH."""
@@ -63,10 +63,10 @@ def get_command_of(commands):
     for command in commands: 
         if is_command_available(command) == True:
             return command
-    print >> sys.stderr, "\nCould not find " + "/".join(commands) + "."
+    print("\nCould not find " + "/".join(commands) + ".", sys.stderr)
     if "rst2html" in commands:
-        print >> sys.stderr, "Please install python-docutils (pip install docutils)."
-    print >> sys.stderr, ""
+        print("Please install python-docutils (pip install docutils).", file=sys.stderr)
+    print("", file=sys.stderr)
     exit(1)
 
 inp = open("README.rst").read().replace("\r\n", "\n")
@@ -99,13 +99,13 @@ for l in lines[2:]:
         tags[name] = value
 
 if "Author" not in tags and "Authors" not in tags:
-    print >> sys.stderr, "Warning: 'Author/Authors' tag is missing. You should tell the world who wrote your module ;)"
+    print("Warning: 'Author/Authors' tag is missing. You should tell the world who wrote your module ;)", file=sys.stderr)
 
 if "License" not in tags:
-    print >> sys.stderr, "Warning: 'License' tag is missing. Under what conditions we can use your module? Can we publish modified versions?"
+    print("Warning: 'License' tag is missing. Under what conditions we can use your module? Can we publish modified versions?", file=sys.stderr)
 
 if "Summary" not in tags:
-    print >> sys.stderr, "Warning: 'Summary' tag is missing. It should be displayed as help in the Modules tab."
+    print("Warning: 'Summary' tag is missing. It should be displayed as help in the Modules tab.", file=sys.stderr)
 
 # extract readme body:
 # intro -> "Description" tag;
@@ -117,7 +117,7 @@ rst2htmlCommand = get_command_of(rst2htmlCommands)
 
 # render the RST as html -> txt without the metadata tags
 # sed command at end is because Windows inserts CR characters all over the place. Removing them should be benign on other platforms. 
-txt = run('cat README.rst | grep -v -E "^:([^:])+:.+$" | ' + rst2htmlCommand + ' | python2 ../html2text.py -b 700 | sed "s/\r$//"')
+txt = run('cat README.rst | grep -v -E "^:([^:])+:.+$" | ' + rst2htmlCommand + ' | python3 ../html2text.py -b 700 | sed "s/\r$//"')
 
 desc = ""
 last_str = "Description"
@@ -129,13 +129,13 @@ for p in txt.strip("\n").split("\n")[2:]:
         add_string(last_str, desc)
         desc = ""
         last_str = "Help page %d" % help_page_num
-        print >> sys.stderr, "Help page %d: %s" % (help_page_num, p.strip('# '))
+        print("Help page %d: %s" % (help_page_num, p.strip('# ')), file=sys.stderr)
         lines_per_page = 0
         p = p[2:].strip()
     desc += "%s\n" % p
     lines_per_page += 1
     if lines_per_page > 18:
-        print >> sys.stderr, "Too many lines per page\n"
+        print("Too many lines per page\n", file=sys.stderr)
         exit(1)
 
 add_string(last_str, desc)


### PR DESCRIPTION
Minimal changes this time.

Turns out it wasn't necessary to update html2text, it just needed a few syntax tweaks for Python 3.

Integer division was also taken care of.