### PR TITLE
RP.160: Add stub for ErrForCamera_handler + DRYOS_ASSERT_HANDLER + increase ML_RESERVED_MEM

### DIFF
--- a/platform/RP.160/consts.h
+++ b/platform/RP.160/consts.h
@@ -37,6 +37,8 @@
 #define MALLOC_STRUCT 0x2A030
 #define MALLOC_FREE_MEMORY (MEM(MALLOC_STRUCT + 8) - MEM(MALLOC_STRUCT + 0x1C)) // "Total Size" - "Allocated Size"
 
+#define DRYOS_ASSERT_HANDLER 0x4000               // from debug_assert function, hard to miss
+
 #define CURRENT_GUI_MODE (*(int*)0x7a50) // see SetGUIRequestMode
 
 #define GUIMODE_PLAY 8194

--- a/platform/RP.160/stubs.S
+++ b/platform/RP.160/stubs.S
@@ -228,7 +228,7 @@ DATA_PTR(    0xFF1C, _rgb_vram_info);
 DATA_PTR(   0x12928,  sd_device)                    // Used as parameter in DryosDebugMsg with "EVICE_POWER_CYCLE bPowerDown=%d" string
 THUMB_FN(0xe06f0358,  _LoadCalendarFromRTC)         // function call after "handle_LOCAL_PLUSMOVIEAUTO_REGIST_HANDLE NewCreate Handle"
                                                     // "Private" as it now has more arguments, needs a wrapper.
-//THUMB_FN(0x,  ErrForCamera_handler)                 // ERR70, ERR80 etc (DlgErrForCamera.c)
+THUMB_FN(0xe088400e,  ErrForCamera_handler)         // ERR70, ERR80 etc (DlgErrForCamera.c)
 
 NSTUB(    0x40D0,  task_max)
 


### PR DESCRIPTION
Those changes are required to make `CONFIG_CRASH_LOG` define work.