### PR TITLE
init.c: my_assert_handler: add 'nullptr' default message, if nullpointer is passed

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -543,6 +543,9 @@ const char* get_assert_msg() { return assert_msg; }
 
 static int my_assert_handler(char* msg, char* file, int line, int arg4)
 {
+    if (msg == NULL)
+        msg = "nullptr";
+
     uint32_t lr = read_lr();
 
 #ifdef CONFIG_DIGIC_678X


### PR DESCRIPTION
This PR fixes an issue on RP firmware (and probably also other firmwares), where many `Debug_Assert` calls are done in a wrong way (canon bug).

Usually the first argument is used as an error description and is assumed being a string. For some reason, many locations of RPs firmware call it using a null pointer which makes the assert handler crash again resulting into less context info being shown on UART. The fix replaces the null pointer by the string "nullptr" in our crash handler before calling canon original handler to avoid the crash in the crash handler.