### PR TITLE
reduce compiler warning on ptpcam

### DIFF
--- a/contrib/ptpcam/libptp-endian.h
+++ b/contrib/ptpcam/libptp-endian.h
@@ -42,10 +42,22 @@
 /* boundaries in order to work properly on all architectures */
 
 /* Uncomment if system endian.h does not provide them */
-#define htobe16(x) htons(x)
-#define htobe32(x) htonl(x)
-#define be16toh(x) ntohs(x)
-#define be32toh(x) ntohl(x)
+
+#ifndef htobe16
+  #define htobe16(x) htons(x)
+#endif // htobe16
+
+#ifndef htobe32
+  #define htobe32(x) htonl(x)
+#endif // htobe32
+
+#ifndef be16toh
+  #define be16toh(x) ntohs(x)
+#endif // be16toh
+
+#ifndef be32toh
+  #define be32toh(x) ntohl(x)
+#endif //be32toh
 
 #define HTOBE16(x) (x) = htobe16(x)
 #define HTOBE32(x) (x) = htobe32(x)
@@ -53,12 +65,29 @@
 #define BE16TOH(x) (x) = be16toh(x)
 
 /* On little endian machines, these macros are null */
-#define htole16(x)      (x)
-#define htole32(x)      (x)
-#define htole64(x)      (x)
-#define le16toh(x)      (x)
-#define le32toh(x)      (x)
-#define le64toh(x)      (x)
+#ifndef htole16
+  #define htole16(x)      (x)
+#endif // htole16
+
+#ifndef htole32
+  #define htole32(x)      (x)
+#endif // htole32
+
+#ifndef htole64
+  #define htole64(x)      (x)
+#endif // htole64
+
+#ifndef le16toh
+  #define le16toh(x)      (x)
+#endif // le16toh
+
+#ifndef le32toh
+  #define le32toh(x)      (x)
+#endif // le32toh
+
+#ifndef le64toh
+  #define le64toh(x)      (x)
+#endif // le64toh
 
 #define HTOLE16(x)      (void) (x)
 #define HTOLE32(x)      (void) (x)

--- a/contrib/ptpcam/ptp.c
+++ b/contrib/ptpcam/ptp.c
@@ -2368,7 +2368,7 @@ void ptp_chdk_print_script_message(ptp_chdk_script_msg *msg) {
   // 
   switch(msg->subtype) {
     case PTP_CHDK_TYPE_UNSUPPORTED:
-      printf("unsupported data type: ",msg->data);
+      printf("unsupported data type: %d",msg->subtype);
       fwrite(msg->data,msg->size,1,stdout); // may not be null terminated
       break;
 

--- a/contrib/ptpcam/ptp.c
+++ b/contrib/ptpcam/ptp.c
@@ -1943,7 +1943,7 @@ int ptp_chdk_reboot_fw_update(char *path, PTPParams* params, PTPDeviceInfo* devi
   return ret;
 }
 
-char* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo)
+void* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo)
 {
   uint16_t ret;
   PTPContainer ptp;

--- a/contrib/ptpcam/ptp.c
+++ b/contrib/ptpcam/ptp.c
@@ -30,6 +30,8 @@
 
 #ifdef WIN32
 #include <winsock2.h>
+#else
+#include <unistd.h>
 #endif
 
 #ifdef ENABLE_NLS

--- a/contrib/ptpcam/ptp.c
+++ b/contrib/ptpcam/ptp.c
@@ -34,6 +34,19 @@
 #include <unistd.h>
 #endif
 
+#ifndef UINTPTR_MAX
+    #error "No UINTPTR_MAX available, cannot safely build"
+#endif
+#if UINTPTR_MAX != 0xffffffff
+    #error "This code assumes 32-bit pointers, refusing to build."
+// This code was clearly intended for a 32-bit host, making assumptions
+// about pointer width in a few places, and packing values into buffers.
+// Is it possible to overflow buffers on cam if the host is 64-bit?
+// Looks plausible to me, so, I'm disabling such builds.
+// I might be wrong, feel free to confirm this and/or fix the code
+// to be portable.
+#endif
+
 #ifdef ENABLE_NLS
 #  include <libintl.h>
 #  undef _

--- a/contrib/ptpcam/ptp.c
+++ b/contrib/ptpcam/ptp.c
@@ -1950,7 +1950,7 @@ void* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* 
   char *buf = NULL;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=3;
   ptp.Param1=PTP_CHDK_GetMemory;
   ptp.Param2=start;
@@ -1972,7 +1972,7 @@ char* ptp_chdk_gdb_upload(PTPParams* params, PTPDeviceInfo* deviceinfo)
   char *buf = NULL;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_GDBStub_Upload;
   ptp.Param2=1024;
@@ -1993,7 +1993,7 @@ int ptp_chdk_gdb_download(char *buf, PTPParams* params, PTPDeviceInfo* deviceinf
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_GDBStub_Download;
   ptp.Param2=strlen(buf);
@@ -2014,7 +2014,7 @@ int ptp_chdk_set_memory_long(int addr, int val, PTPParams* params, PTPDeviceInfo
   char *buf = (char *) &val;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=3;
   ptp.Param1=PTP_CHDK_SetMemory;
   ptp.Param2=addr;
@@ -2034,7 +2034,7 @@ int ptp_chdk_call(int *args, int size, int *ret, PTPParams* params, PTPDeviceInf
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_CallFunction;
   ptp.Param2=size;
@@ -2073,7 +2073,7 @@ int ptp_chdk_upload(char *local_fn, char *remote_fn, PTPParams* params, PTPDevic
   int s,l;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_UploadFile;
 
@@ -2116,7 +2116,7 @@ int ptp_chdk_download(char *remote_fn, char *local_fn, PTPParams* params, PTPDev
   FILE *f;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_TempData;
   ptp.Param2=0;
@@ -2128,7 +2128,7 @@ int ptp_chdk_download(char *remote_fn, char *local_fn, PTPParams* params, PTPDev
   }
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_DownloadFile;
 
@@ -2179,7 +2179,7 @@ int ptp_chdk_exec_lua(char *script, int get_result, PTPParams* params, PTPDevice
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_ExecuteScript;
   ptp.Param2=PTP_CHDK_SL_LUA;
@@ -2237,7 +2237,7 @@ int ptp_chdk_get_version(PTPParams* params, PTPDeviceInfo* deviceinfo, int *majo
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_Version;
   r=ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL);
@@ -2256,7 +2256,7 @@ int ptp_chdk_get_script_status(PTPParams* params, PTPDeviceInfo* deviceinfo, int
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_ScriptStatus;
   r=ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL);
@@ -2274,7 +2274,7 @@ int ptp_chdk_get_script_support(PTPParams* params, PTPDeviceInfo* deviceinfo, in
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_ScriptSupport;
   r=ptp_transaction(params, &ptp, PTP_DP_NODATA, 0, NULL);
@@ -2298,7 +2298,7 @@ int ptp_chdk_write_script_msg(PTPParams* params, PTPDeviceInfo* deviceinfo, char
 	return 0;
   }
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=2;
   ptp.Param1=PTP_CHDK_WriteScriptMsg;
   ptp.Param2=script_id; // TODO test don't care ?
@@ -2320,7 +2320,7 @@ int ptp_chdk_read_script_msg(PTPParams* params, PTPDeviceInfo* deviceinfo,ptp_ch
   PTPContainer ptp;
 
   PTP_CNT_INIT(ptp);
-  ptp.Code=PTP_OC_CHDK;
+  ptp.Code=PTP_OC_CANON_CHDK;
   ptp.Nparam=1;
   ptp.Param1=PTP_CHDK_ReadScriptMsg;
   char *data = NULL;

--- a/contrib/ptpcam/ptp.h
+++ b/contrib/ptpcam/ptp.h
@@ -1045,5 +1045,6 @@ typedef struct {
 
 int ptp_chdk_print_all_script_messages(PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_write_script_msg(PTPParams* params, PTPDeviceInfo* deviceinfo, char *data, unsigned size, int *status);
+void ptp_chdk_print_script_message(ptp_chdk_script_msg* msg);
 
 #endif /* __PTP_H__ */

--- a/contrib/ptpcam/ptp.h
+++ b/contrib/ptpcam/ptp.h
@@ -1018,7 +1018,7 @@ int ptp_chdk_shutdown_hard(PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_shutdown_soft(PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_reboot(PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_reboot_fw_update(char *path, PTPParams* params, PTPDeviceInfo* deviceinfo);
-char* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo);
+void* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_set_memory_long(int addr, int val, PTPParams* params, PTPDeviceInfo* deviceinfo);
 int ptp_chdk_call(int *args, int size, int *ret, PTPParams* params, PTPDeviceInfo* deviceinfo);
 int* ptp_chdk_get_propcase(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo);

--- a/contrib/ptpcam/ptp.h
+++ b/contrib/ptpcam/ptp.h
@@ -910,8 +910,6 @@ protocol version history
 2.0 - return PTP_CHDK_TYPE_TABLE for tables instead of TYPE_STRING, allow return of empty strings
 */
 
-#define PTP_OC_CHDK 0x9999
-
 // N.B.: unused parameters should be set to 0
 enum ptp_chdk_command {
   PTP_CHDK_Version = 0,     // return param1 is major version number

--- a/contrib/ptpcam/ptpcam.c
+++ b/contrib/ptpcam/ptpcam.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <fcntl.h>
+#include <sys/time.h>
 #ifndef WIN32
 #include <sys/mman.h>
 #endif

--- a/src/ptp.h
+++ b/src/ptp.h
@@ -11,25 +11,6 @@
  * and will be called when the host initiates that operation.
  */
 
-/** \group PTP IDs
- *
- * These are some of the "well known" Canon PTP commands.
- * @{
- */
-#define PTP_FM_OBJECTSIZE       0x910a
-#define PTP_SET_DEVICE_PROP     0x9110
-#define PTP_HD_CAPACITY         0x911a
-#define PTP_GUI_OFF             0x911b
-#define PTP_LCD_ON              0x911c
-#define PTP_911E                0x911e  // unknown
-#define PTP_UPDATE_FIRMARE      0x911f
-#define PTP_LV_DATA             0x9153
-#define PTP_LV_ZOOM_MAYBE       0x9154
-#define PTP_LV_ZOOM             0x9158
-#define PTP_LV_AFFRAME          0x915a
-#define PTP_AF_START            0x9160
-#define PTP_FAPI_MESSAGE_TX     0x91fe
-
 // results
 #define PTP_RC_OK               0x2001
 #define PTP_RC_ERROR            0x2002


### PR DESCRIPTION
This PR reduces compiler warnings which occur when building `contrib/ptpcam`. By defining missing function protoypes, using correct return types of functions, add missing includes, fixing wrong or missing format specifiers in format strings etc.

As a piggy back some local redundant and unused PTP command IDs are removed from ptp.h, as they are already defined in https://github.com/reticulatedpines/magiclantern_simplified/blob/dev/contrib/ptpcam/ptp-eos-oc.h

However, there is still one warning left around line 1019:

```
ptp.h:1019:7: note: expected ‘int’ but argument is of type ‘uint32_t * {aka unsigned int *}’
 void* ptp_chdk_get_memory(int start, int num, PTPParams* params, PTPDeviceInfo* deviceinfo);
       ^~~~~~~~~~~~~~~~~~~
ptpcam.c:3053:55: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                             uint32_t buffer_address = (uint32_t)ptpbuf->buffers + (num * (ptpbuf->buffer_size + 4));
```

As I don't know how to fix it yet, I leave it as is for now.