### PR TITLE
compositor.c: add XCM support for newer models

### DIFF
--- a/platform/850D.100/features.h
+++ b/platform/850D.100/features.h
@@ -18,7 +18,12 @@
 
 // Needed for consistent ML display due to racing
 // for vram layers
+// enable XCM only in full build
+#ifndef ML_MINIMAL_OBJ
 #define CONFIG_COMPOSITOR_XCM
+#define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_XCM_V2
+#endif
 
 // mostly working - task display is too crowded.
 // Maybe CPU usage should update faster?

--- a/platform/850D.100/stubs.S
+++ b/platform/850D.100/stubs.S
@@ -228,13 +228,22 @@ THUMB_FN(0xe07f40f0, _LoadCalendarFromRTC)
 
 
 // These are required on Digic 678
-THUMB_FN(0xe074623c, RefreshVrmsSurface) // "Call RefreshVrmsSurface" / "XimrExe"
-DATA_PTR(   0x11738,  display_refresh_needed) // if 0, RefreshVrmsSurface() does nothing
+
 THUMB_FN(0xe00da090, XimrExe) // trigger Ximr unit to execute (HW compositor, partially understood)
 DATA_PTR(   0x11724,  winsys_sem)
-
 THUMB_FN(0xe00ddee0,  XCM_GetSourceSurface)
 DATA_PTR(  0x12dd58, _pXCM)
+
+/**
+ * Stubs needed for CONFIG_XCM_DEDICATED_LAYER
+ */
+THUMB_FN(0xe074623c, refreshVrmsSurface)            // "VMIX_TransferRectangleToVram"
+DATA_PTR(   0x11738, display_refresh_needed)        // if 0, RefreshVrmsSurface() does nothing
+DATA_PTR(  0x12dbb0, RENDERER_LayersMetadata);      // accessed in for loop in RENDERER_InitializeScreen()
+THUMB_FN(0xe00ddc2c, XCM_SetSourceSurface);
+THUMB_FN(0xe00ddf14, XCM_SetSourceArea);
+THUMB_FN(0xe07465cc, XOC_SetLayerEnable);
+THUMB_FN(0xe00de668, XCM_SetColorMatrixType);
 
 // These are not strictly required, although recent dev work has added dependencies;
 // these likely should be removed before a "real" release

--- a/platform/R.180/features.h
+++ b/platform/R.180/features.h
@@ -4,6 +4,7 @@
 #ifndef ML_MINIMAL_OBJ
 #define CONFIG_COMPOSITOR_XCM
 #define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_XCM_V1
 #endif
 
 // Don't Click Me menu looks to be intended as a place

--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -281,9 +281,9 @@ DATA_PTR(    0xFE6C, display_refresh_needed)                // Easy to spot in r
  * Structures needed for CONFIG_XCM_DEDICATED_LAYER. Specific for EOS R only!
  * See https://www.magiclantern.fm/forum/index.php?topic=26024
  */
-DATA_PTR(   0x6EFA0, RENDERER_LayersArr);
-DATA_PTR(   0x6F2A4, VMIX_LayersArr);
-DATA_PTR(   0x6F2BC, VMIX_LayersEnableArr);
+DATA_PTR(   0x6EFA0, RENDERER_Layers);
+DATA_PTR(   0x6F2A4, VMIX_Layers);
+DATA_PTR(   0x6F2BC, VMIX_LayersEnable);
 
 /**
  * General FEATURE_VRAM_RGBA stubs

--- a/platform/RP.160/features.h
+++ b/platform/RP.160/features.h
@@ -3,8 +3,8 @@
 //enable XCM only in full build
 #ifndef ML_MINIMAL_OBJ
 #define CONFIG_COMPOSITOR_XCM
-// DEDICATED_LAYER not yet implemented
-//#define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_XCM_V2
 #endif
 
 #define FEATURE_SHOW_SHUTTER_COUNT

--- a/platform/RP.160/stubs.S
+++ b/platform/RP.160/stubs.S
@@ -211,6 +211,10 @@ DATA_PTR(    0xFF78, _pXCM);                        // param1 to XCM_MakeContext
  */
 THUMB_FN(0xe0254b0c, refreshVrmsSurface);           // by debug message.
 DATA_PTR(    0xFF74, display_refresh_needed)        // Easy to spot in refreshVrmsSurface()
+DATA_PTR(   0x720f0, RENDERER_LayersMetadata);
+THUMB_FN(0xe010ef6a, XCM_SetSourceSurface);
+THUMB_FN(0xe010efd4, XCM_SetSourceArea);
+THUMB_FN(0xe0254e8c, XOC_SetLayerEnable);
 
 /**
  * General FEATURE_VRAM_RGBA stubs

--- a/platform/SX70.111/features.h
+++ b/platform/SX70.111/features.h
@@ -1,5 +1,12 @@
 #define FEATURE_VRAM_RGBA
 
+//enable XCM only in full build
+#ifndef ML_MINIMAL_OBJ
+#define CONFIG_COMPOSITOR_XCM
+#define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_XCM_V2
+#endif
+
 // Don't Click Me menu looks to be intended as a place
 // for devs to put custom code in debug.c run_test(),
 // and allowing triggering from a menu context.

--- a/platform/SX70.111/stubs.S
+++ b/platform/SX70.111/stubs.S
@@ -179,6 +179,30 @@ THUMB_FN(0xE0110BD0, XimrExe);                              // In RefreshVrmsSur
 DATA_PTR(    0xFB88, winsys_sem);                           // Used in RefreshVrmsSurface around XimrExe call
 DATA_PTR(    0xFB38, _rgb_vram_info);
 
+/**
+ * Things needed for CONFIG_COMPOSITOR_XCM.
+ *
+ * RP uses two layers (GUI, focus overlays). WINSYS code swaps pointer in
+ * WINSYS structure (one we know as _rgb_vram_info) to select which layer to
+ * draw.
+ *
+ * With FEATURE_COMPOSITOR_XCM we ask XCM via XCM_GetSourceSurface to give us
+ * pointer to layer 0, which is more reliable.
+ */
+THUMB_FN(0xe01171e8, XCM_GetSourceSurface)          // by debug message
+//THUMB_FN(0xe0116fb0, XCM_MakeContext)             // by debug message. Not used in code, left for reference below.
+DATA_PTR(    0xfba0, _pXCM);                        // param1 to XCM_MakeContext() when called from refreshVrmsSurface()
+
+/**
+ * Stubs needed for CONFIG_XCM_DEDICATED_LAYER
+ */
+THUMB_FN(0xe0234aac, refreshVrmsSurface);           // by debug message.
+DATA_PTR(    0xfb9c, display_refresh_needed)        // Easy to spot in refreshVrmsSurface()
+DATA_PTR(   0x6aaac, RENDERER_LayersMetadata);      // accessed in for loop in RENDERER_InitializeScreen()
+THUMB_FN(0xe01171ae, XCM_SetSourceSurface);
+THUMB_FN(0xe0117218, XCM_SetSourceArea);
+THUMB_FN(0xe0234e2c, XOC_SetLayerEnable);
+
 /** Wrong on purpose **/
 DATA_PTR(       0x0,  LCD_Palette)                          // D6+ do use palletes to draw GUI, but it is hw rendered into RGBA
 

--- a/platform/SX740.102/features.h
+++ b/platform/SX740.102/features.h
@@ -4,6 +4,7 @@
 #ifndef ML_MINIMAL_OBJ
 #define CONFIG_COMPOSITOR_XCM
 #define CONFIG_COMPOSITOR_DEDICATED_LAYER
+#define CONFIG_COMPOSITOR_XCM_V1
 #endif
 
 // Don't Click Me menu looks to be intended as a place

--- a/platform/SX740.102/stubs.S
+++ b/platform/SX740.102/stubs.S
@@ -217,11 +217,11 @@ DATA_PTR(    0xF450, display_refresh_needed)                // Easy to spot in r
 
 /**
  * Structures needed for CONFIG_XCM_DEDICATED_LAYER. Specific for SX740 only!
- * Differs from R by not having VMIX_LayersEnableArr.
+ * Differs from R by not having VMIX_LayersEnable.
  * See https://www.magiclantern.fm/forum/index.php?topic=26024
  */
-DATA_PTR(   0x9FCAC, RENDERER_LayersArr);
-DATA_PTR(   0x9FFB0, VMIX_LayersArr);
+DATA_PTR(   0x9FCAC, RENDERER_Layers);
+DATA_PTR(   0x9FFB0, VMIX_Layers);
 
 /**
  * General FEATURE_VRAM_RGBA stubs

--- a/src/bmp.c
+++ b/src/bmp.c
@@ -214,7 +214,7 @@ void refresh_yuv_from_rgb(void)
         }
     }
     else{
-#ifdef CONFIG_DIGIC_X
+#if defined(CONFIG_DIGIC_X) && !defined(CONFIG_COMPOSITOR_DEDICATED_LAYER)
         // kitor FIXME this is the loop altered to work with 2048x1080 layers.
         // Resolution needs confirmation on R6.
         //

--- a/src/bmp.h
+++ b/src/bmp.h
@@ -31,6 +31,7 @@
 #include "dryos.h"
 #include "font.h"
 #include "rbf_font.h"
+#include "compositor.h"
 
 extern int bmp_enabled;
 
@@ -54,10 +55,6 @@ inline uint8_t* bmp_vram_raw() { return bmp_vram_info[1].vram2; }
  * arbitrary layer on runtime (eg with compositor enabled)
  */
 extern struct MARV *rgb_vram_info;
-#ifdef CONFIG_COMPOSITOR_XCM
-extern void* _pXCM;
-extern struct MARV *XCM_GetSourceSurface(void *pXCM, uint32_t layer_id);
-#endif
 /**
  * _rgb_vram_info stubs is not needed in CONFIG_COMPOSITOR_XCM,
  * but it breaks minimal builds that do not support compositor stuff.
@@ -153,7 +150,7 @@ inline uint8_t *bmp_vram_raw() {
     #define SET_4BIT_PIXEL(p, x, color) *(char*)(p) = ((x) % 2) ? ((*(char*)(p) & 0x0F) | (D2V(color) << 4)) : ((*(char*)(p) & 0xF0) | (D2V(color) & 0x0F))
 
 #else // dryos
-    #if defined(CONFIG_DIGIC_X)
+    #if defined(CONFIG_DIGIC_X) && !defined(CONFIG_COMPOSITOR_DEDICATED_LAYER)
     // kitor FIXME: R5 has different layer size and position...
     // this is a temporary integration before a proper one will be developed
     #define BMP_W_PLUS   872

--- a/src/compositor.h
+++ b/src/compositor.h
@@ -65,4 +65,9 @@ void compositor_layer_clear();
 // ID of our allocated layer. See compositor.c for initialization.
 extern int _rgb_vram_layer_id; // = CANON_GUI_LAYER_ID;
 
+#ifdef CONFIG_COMPOSITOR_XCM
+extern void* _pXCM;
+extern struct MARV *XCM_GetSourceSurface(void *pXCM, uint32_t layer_id);
+#endif
+
 #endif

--- a/src/vram.h
+++ b/src/vram.h
@@ -57,6 +57,10 @@ struct MARV
     uint32_t signature;         /* MARV - VRAM reversed */
     uint8_t * bitmap_data;      /* either UYVY or UYVY + opacity */
     uint8_t * opacity_data;     /* optional; if missing, it's interleaved in bitmap_data */
+    #ifdef CONFIG_DIGIC_X
+    uint32_t memif_1;           /* meaning unknown, seems to be set as 0xFFFFFFFF */
+    uint64_t ibus_addr;         /* 64 bit IBus address for bitmap_data? */
+    #endif
     uint32_t flags;             /* unknown */
     uint32_t width;             /* X resolution; may be larger than screen size */
     uint32_t height;            /* Y resolution; may be larger than screen size */


### PR DESCRIPTION
Updates to bring `CONFIG_COMPOSITOR_DEDICATED_LAYER`  (or drawing on dedicated compositor layer) working on RP and newer models. Starting from RP Canon standardized the API.

Old implementation was based on EOS R which had some early-implementation quirks - those are shared only with SX740.
New implementation should support all Digic 8 models with XCM (thus M50 is excluded, as it is the last camera with pure Ximr), and incorporates (disabled) code paths for Digic X support.

Digic X support is disabled as while API is +/- the same, we don't know how to allocate memory on specific IBus, and XCM now requires it to happen, else code will assert.

This PR changes most of compositor.c, thus don't read it the diff, read the file - diff makes no sense.

Tested R/RP/SX70/SX740. 850D done blindly, requires checking if camera still boots. If it does, shall print something like this on UART on boot:

```
     2885:   1048.119 starting menu_redraw_task
     2886:   1048.919 Canon layer: 0x02e18500
     2887:   1048.930 Found 2 layers
     2896:   1051.403 MARV 0x0012b3a8, bitmap_data 0x49a55494
     2897:   1055.164 Our layer: 0x0012b3a8
```