### PR TITLE
Fixes to intervalometer and SRM memory

### DIFF
--- a/platform/7D2.112/consts.h
+++ b/platform/7D2.112/consts.h
@@ -25,6 +25,7 @@
 /* "Malloc Information" */
 #define MALLOC_STRUCT 0x41b50                    // from get_malloc_info, helper of malloc_info
 #define MALLOC_FREE_MEMORY (MEM(MALLOC_STRUCT + 8) - MEM(MALLOC_STRUCT + 0x1C)) // "Total Size" - "Allocated Size"
+#define SRM_BUFFER_SIZE  0x2314000   /* print it from srm_malloc_cbr */
 
 /* high confidence */
 #define DRYOS_ASSERT_HANDLER 0x28d50               // from debug_assert function, hard to miss
@@ -58,7 +59,7 @@
 
 #define CANON_SHUTTER_RATING 200000
 
-    #define DISPLAY_IS_ON               0x1  // TODO: find real value
+#define DISPLAY_IS_ON ((MEM(0x027e98) & 0x100) ? 0 : 1)  // found at 0xfe0b6824 : MEM(0x027e98) == 0x10001(on) 0x10101(off)
 
 #define GMT_FUNCTABLE 0xfe658084           // from gui_main_task
 #define GMT_NFUNCS 0x7                  // size of table above
@@ -166,3 +167,7 @@
 //address of XimrContext structure to redraw in FEATURE_VRAM_RGBA
 //0x5d138 + 0x10 is pointer to XimrContext struct
 #define XIMR_CONTEXT ((void*)0x5d148)
+
+// Safe settings 
+#define BULB_EXPOSURE_CORRECTION 0
+#define BULB_MIN_EXPOSURE 500

--- a/platform/7D2.112/consts.h
+++ b/platform/7D2.112/consts.h
@@ -59,7 +59,7 @@
 
 #define CANON_SHUTTER_RATING 200000
 
-#define DISPLAY_IS_ON ((MEM(0x027e98) & 0x100) ? 0 : 1)  // found at 0xfe0b6824 : MEM(0x027e98) == 0x10001(on) 0x10101(off)
+#define DISPLAY_IS_ON (!(char)(MEM(0x27e99)))  // found at 0xfe0b6824 : MEM(0x027e98) == 0x10001(on) 0x10101(off)
 
 #define GMT_FUNCTABLE 0xfe658084           // from gui_main_task
 #define GMT_NFUNCS 0x7                  // size of table above

--- a/platform/7D2.112/features.h
+++ b/platform/7D2.112/features.h
@@ -7,7 +7,7 @@
 // and allowing triggering from a menu context.
 #define FEATURE_DONT_CLICK_ME
 
-//#define FEATURE_SHOW_SHUTTER_COUNT
+#define FEATURE_SHOW_SHUTTER_COUNT
 
 // working but incomplete, some allocators don't report
 // anything yet as they're faked / not yet found
@@ -32,3 +32,7 @@
 // explicitly disable stuff that don't work or may break things
 #undef CONFIG_AUTOBACKUP_ROM
 #undef CONFIG_ADDITIONAL_VERSION
+
+// full intervalometer requires CONFIG_PROP_REQUEST_CHANGE + "bool is_prop_allowed(...){ return true;}"
+#define FEATURE_INTERVALOMETER
+#define FEATURE_BULB_TIMER

--- a/platform/7D2.112/internals.h
+++ b/platform/7D2.112/internals.h
@@ -31,4 +31,4 @@
 
 // This camera has BULB mode
 #define CONFIG_BULB
-#define CONFIG_SEPAEATE_BULB_MODE // has "B" mode
+#define CONFIG_SEPARATE_BULB_MODE // has "B" mode

--- a/platform/7D2.112/internals.h
+++ b/platform/7D2.112/internals.h
@@ -18,10 +18,6 @@
 // enable state objects hooks
 #define CONFIG_STATE_OBJECT_HOOKS
 
-// SRM is untested, this define is to allowing building
-// without SRM_BUFFER_SIZE being found
-#define CONFIG_MEMORY_SRM_NOT_WORKING
-
 // Cam has very few spare tasks for ML, steal more mem
 // during boot to raise the limit
 #define CONFIG_INCREASE_MAX_TASKS 4
@@ -32,3 +28,7 @@
 #define CONFIG_NEW_TASK_STRUCTS
 #define CONFIG_TASK_STRUCT_V2
 #define CONFIG_TASK_ATTR_STRUCT_V3
+
+// This camera has BULB mode
+#define CONFIG_BULB
+#define CONFIG_SEPAEATE_BULB_MODE // has "B" mode


### PR DESCRIPTION
DISPLAY_IS_ON fixed
SRM_BUFFER_SIZE fixed
Constants  and features  for intervalomater added
Intervalometer was tested with PROP_REQUEST_CHANGE + is_prop_alloweD(...) {return true;}