### PR TITLE
adtg2log: add hook for RP

### DIFF
--- a/modules/dev_tools/adtglog2/Makefile
+++ b/modules/dev_tools/adtglog2/Makefile
@@ -3,6 +3,7 @@ MODULE_NAME = adtglog2
 MODULE_OBJS = $(BUILD_DIR)/adtglog2.o \
               $(BUILD_DIR)/hooks_thumb_200D.o \
               $(BUILD_DIR)/hooks_thumb_6D2.o \
+              $(BUILD_DIR)/hooks_thumb_RP.o \
               $(BUILD_DIR)/hooks_arm_70D.o
 TOP_DIR = ../../..
 
@@ -20,6 +21,9 @@ $(BUILD_DIR)/hooks_thumb_200D.o: hooks_thumb_200D.c
 	$(CC) $(CFLAGS_ARCHLESS) -mthumb -march=armv7 $(CDEPS_FLAGS) -c -o $@ $<
 
 $(BUILD_DIR)/hooks_thumb_6D2.o: hooks_thumb_6D2.c
+	$(CC) $(CFLAGS_ARCHLESS) -mthumb -march=armv7 $(CDEPS_FLAGS) -c -o $@ $<
+
+$(BUILD_DIR)/hooks_thumb_RP.o: hooks_thumb_RP.c
 	$(CC) $(CFLAGS_ARCHLESS) -mthumb -march=armv7 $(CDEPS_FLAGS) -c -o $@ $<
 
 $(BUILD_DIR)/hooks_arm_70D.o: hooks_arm_70D.c

--- a/modules/dev_tools/adtglog2/adtglog2.c
+++ b/modules/dev_tools/adtglog2/adtglog2.c
@@ -245,6 +245,34 @@ static unsigned int init()
         }
         apply_patches(patches, COUNT(f_patches));
     }
+    else if (is_camera("RP", "1.6.0"))
+    {
+        buf_item_size = 32;
+
+        // install hooks
+        struct function_hook_patch f_patches[] = {
+            {
+                .patch_addr = 0xe067b7e0, // CMOS_write
+                .orig_content = {0x2d, 0xe9, 0xfc, 0x5f, 0x04, 0x46, 0x9b, 0x4e},
+                .target_function_addr = (uint32_t)hook_CMOS_write_RP,
+                .description = "Log ADTG CMOS writes"
+            },
+        };
+
+        struct patch patches[COUNT(f_patches)] = {};
+        uint8_t code_hooks[8 * COUNT(f_patches)] = {};
+
+        for (int i = 0; i < COUNT(f_patches); i++)
+        {
+            if (convert_f_patch_to_patch(&f_patches[i],
+                                         &patches[i],
+                                         &code_hooks[8 * i]))
+            {
+                return 1;
+            }
+        }
+        apply_patches(patches, COUNT(f_patches));
+    }
     else if (is_camera("70D", "1.1.2"))
     {
         buf_item_size = 16;

--- a/modules/dev_tools/adtglog2/hooks_thumb.h
+++ b/modules/dev_tools/adtglog2/hooks_thumb.h
@@ -8,5 +8,6 @@
 // one instruction in Thumb, so it's harder to be as generic as the ARM hook code.
 void __attribute__((noreturn,noinline,naked,aligned(4)))hook_CMOS_write_200D(void);
 void __attribute__((noreturn,noinline,naked,aligned(4)))hook_CMOS_write_6D2(void);
+void __attribute__((noreturn,noinline,naked,aligned(4)))hook_CMOS_write_RP(void);
 
 #endif

--- a/modules/dev_tools/adtglog2/hooks_thumb_RP.c
+++ b/modules/dev_tools/adtglog2/hooks_thumb_RP.c
@@ -1,0 +1,34 @@
+#include "adtglog2.h"
+#include "hooks_thumb.h"
+#include "dryos.h"
+#include "log.h"
+
+// ADTG logging
+
+void __attribute__((noreturn,noinline,naked,aligned(4)))hook_CMOS_write_RP(void)
+{
+    asm(
+        "push { r2-r12, lr }\n"
+    );
+
+    uint32_t *cmos_buf;
+    uint32_t lr;
+    asm __volatile__ (
+        "mov %0, r0\n"
+        "mov %1, lr\n" : "=&r"(cmos_buf), "=&r"(lr)
+    );
+
+    log_cmos_command_buffer(cmos_buf, lr);
+
+    asm(
+        "pop { r2-r12, lr }\n"
+
+        // do overwritten instructions
+        "push  {r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, lr}\n"
+        "mov   r4, r0\n"
+        "ldr   r6, =0x6b9c4\n"
+
+        // jump back
+        "ldr pc, =0xe067b7e9\n"
+    );
+}


### PR DESCRIPTION
This PR adds the hook for adtg2log for RP 1.6.0. I have used 200D as a template.
Implementation is untested yet.

adtg2log requires MMU to work. Thus cannot be merged until https://github.com/reticulatedpines/magiclantern_simplified/pull/163 works.