### PR TITLE
Fix deprecation warning

### DIFF
--- a/modules/readme2modulestrings.py
+++ b/modules/readme2modulestrings.py
@@ -61,9 +61,8 @@ def declare_string_section():
     
 def is_command_available(name):
     """Check if command `name` is on PATH."""
-    import distutils.spawn
-    from distutils.spawn import find_executable
-    return find_executable(name) is not None
+    import shutil
+    return shutil.which(name) is not None
 
 # return the first command of the list that can be found on the OS
 def get_command_of(commands):


### PR DESCRIPTION
Replace the [deprecated distutils](https://mail.python.org/archives/list/python-dev@python.org/thread/TXU6TVOMBLQU3SV57DMMOA5Y2E67AW7P/) call in Python 3.10-11, by [shutil](https://docs.python.org/3/library/shutil.html#shutil.which) ([recommended replace](https://peps.python.org/pep-0632/#:~:text=distutils.spawn.find_executable%20%E2%80%94%20use%20the%20shutil.which%20function))

