### PR TITLE
We often don't declare function params in header files, we should

### DIFF
--- a/src/lens.h
+++ b/src/lens.h
@@ -895,7 +895,6 @@ void set_htp(int value);
 
 /* camera ready to take a picture or change shooting settings? */
 int job_state_ready_to_take_pic();
-void lens_wait_readytotakepic();
 
 /* force an update of PROP_LV_LENS outside LiveView */
 void _prop_lv_lens_request_update();


### PR DESCRIPTION
Perhaps this was intentional but it's not necessary.

EDIT: original submission had incorrect title and no description of the problem here.  The reported problem was that we have incompatible double definitions of some functions, e.g. lens_wait_readytotakepic() in lens.h.  The definition was not incompatible, but it shows a real problem, which is larger.  Probably it is not serious, but, it is ugly.