### PR TITLE
Support for a Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM archlinux:latest
+
+RUN pacman --noconfirm -Syu && \
+    pacman --noconfirm -S make python3 python-pip python-distutils-extra python-docutils gcc arm-none-eabi-gcc arm-none-eabi-newlib inetutils zip && \
+    rm /var/cache/pacman/pkg/*
+
+# Create the build user
+RUN useradd -m build && \
+    # Delete the build users password
+    passwd -d build && \
+    # Allow the build user passwordless sudo
+    printf 'build ALL=(ALL) ALL\n' | tee -a /etc/sudoers
+
+USER build

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,21 @@
+# What is this?
+This directory defines a "Dev Containers" environment that provides all necessary tools to compile "Magic Lantern" while keeping the host system clean of these dependencies.
+
+# Prerequisites
+* Install the "Dev Containers" extension for Visual Studio Code (`ms-vscode-remote.remote-containers`)
+* Make sure that Docker is installed and running
+
+# Usage
+Open the root directory of the Git repository in Visual Studio Code. A dialog with the option "Reopen in Container" should pop up. Click it to build and enter the container environment. In case the dialog is not present select "Dev Containers: Reopen in Container" from the command palette.
+
+In the container you can now open a new terminal and build "Magic Lantern as follows" with the following commands:
+```
+cd platform
+# Adjust to your number of cores
+make -j 12
+```
+
+# Notes
+The user in the container is called `build` and has a user id and group id of 1000. These ids should in most cases coincide with the ids of the user of a single user Linux system. If that's the case then all files which are created during the build should have be owned by the user on the host system.
+
+To save some space Git is not installed in the dev container environment as it is assumed that it is present on the host system anyway.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "Magic Lantern",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ syntax: glob
 *.elf
 !src/libs/*/*.a
 *.fir
-.*
 !.hgignore
 !.gitignore
 .*.swp


### PR DESCRIPTION
Add support for a Dev Container which is based on Arch Linux.

Please refer to the added README.md for more details.

Remove the `.*` line from the `.gitignore` so that the `.devcontainer` directory can be added.