### PR TITLE
Wrap documentation to 80 columns (and grammar)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,135 +1,198 @@
 Introduction to Magic Lantern
 =============================
 
-Hello, potential camera hacker!  Have a Canon EOS camera and want to make it do extra things?  Wondering why Magic Lantern isn't on your camera yet?  Do you enjoy low-level messing around and exploring undocumented systems?  Or, you think you would and want to learn?  Give it a try, it's fun, if a little tricky sometimes.
+Hello, potential camera hacker!
+
+Have a Canon EOS camera and want to make it do extra things? Wondering why
+Magic Lantern isn't on your camera yet?  Do you enjoy low-level messing around
+and exploring undocumented systems? Or, you think you would and want to learn?
+Give it a try, it's fun, if a little tricky sometimes.
 
 Anyone who can help us keep things working and improving is greatly appreciated!
 
-Building ML should work on Linux, Windows (WSL), or Mac (probably BSDs generally).
+Building ML should work on Linux, Windows (WSL), or Mac (probably *nix, BSDs).
 
-There are many possible ways to help out with the code, with different skills required.  We're pretty friendly to anyone that shows an interest and can help you learn any of these things, but it's not going to be quick:
+There are many possible ways to help out with the code, with different skills
+required. We're pretty friendly to anyone that shows an interest and can help
+you learn any of these things, but it's not going to be quick:
 
-  - Maintaining existing camera support (mostly C)
-  - Adding support for new cameras (C, reverse engineering tools e.g. Ghidra / IDA Pro, sometimes ARM assembly)
-  - Keeping things working / Magic Lantern infrastructure (make, python, qemu, automation skills)
+- Maintaining existing camera support (mostly C)
+- Adding support for new cameras (C, reverse engineering tools
+  e.g. Ghidra / IDA Pro, sometimes ARM assembly)
+- Keeping things working / Magic Lantern infrastructure
+  (make, python, qemu, automation skills)
 
-The hard part is understanding how the camera works, and how to get it to do something else.  It's time consuming, often frustrating, but eventually satisfying: you can do things nobody has done before.
+The hard part is understanding how the camera works, and how to get it to do
+something else.  It's time consuming, often frustrating, but eventually
+satisfying: you can do things nobody has done before.
 
-If you're not a coder and don't want to become one, you can still help: consider finding the old and new wiki links in the resource section, and improving documentation.
+If you're not a coder and don't want to become one, you can still help: consider
+finding the old and new wiki links in the resource section, and
+improving documentation.
 
-### New to programming?  New to git?  Etc
-There's a lot more below, about how to keep things consistent and readable for ML code, but there's an overriding rule: we will help you learn.
+### New to programming? New to git? etc.
+There's a lot more below, about how to keep things consistent and readable for
+ML code, but there's an overriding rule: we will help you learn.
 
-So, don't worry too much - we will teach you, so you can skip reading it if you don't mind us telling you to change things later on.
+So, don't worry too much - we will teach you, so you can skip reading it if you
+don't mind us telling you to change things later on.
 
 ### Important note
-This repo is a fork.  However, the official repo is in practice unmaintained.  This repo's primary focus is getting ML working on newer cameras: Digic 6 and later, this begins with 5D mark IV, 750D, 200D era.  We also try to not break existing support.  Bug fixes or enhancements to old or new cams are welcome if there is reasonable confidence we don't break well supported cams.
+This repo is a fork.  However, the official repo is in practice unmaintained.
+This repo's primary focus is getting ML working on newer cameras: Digic 6 and
+later, this begins with 5D mark IV, 750D, 200D era.  We also try to not break
+existing support.  Bug fixes or enhancements to old or new cams are welcome if
+there is reasonable confidence we don't break well supported cams.
 
 # Important resources & contact info
-Magic Lantern started in 2009, there's a lot of background that can be useful to understand.  This is messier than we'd like.  Some things are documented in the code, some on the forum, some in news groups, and some lost forever on IRC because there were no logs.
+Magic Lantern started in 2009, there's a lot of background that can be useful to
+understand.  This is messier than we'd like.  Some things are documented in the
+code, some on the forum, some in news groups, and some lost forever on IRC
+because there were no logs.
 
-If you have problems getting a development environment working, asking in Discord will get you the quickest response.  The forums will also work.
+If you have problems getting a development environment working, asking in
+Discord will get you the quickest response.  The forums will also work.
 
-The origin story!  
+The origin story!
 [https://trmm.net/Magic_Lantern_firmware/](https://trmm.net/Magic_Lantern_firmware/)
 
-The official repo:  
+The official repo:
 [https://foss.heptapod.net/magic-lantern/magic-lantern](https://foss.heptapod.net/magic-lantern/magic-lantern)
 
-Official forum, good for documenting things, or long running discussions that need to be referred to later.  
+Official forum, good for documenting things, or long running discussions that
+need to be referred to later.
 [https://www.magiclantern.fm/forum/](https://www.magiclantern.fm/forum/)
 
-ML Discord, very useful for quick questions, or in-depth discussions.  Most dev chat happens here.  
+ML Discord, very useful for quick questions, or in-depth discussions.
+Most dev chat happens here.
 [https://discord.gg/srY7GhQjYN](https://discord.gg/srY7GhQjYN)
 
-Newsgroups, mostly defunct now, but can be valuable for reference at times.  
+Newsgroups, mostly defunct now, but can be valuable for reference at times.
 [https://groups.google.com/g/ml-devel](https://groups.google.com/g/ml-devel)
 
-The old wiki, has more content, but is sometimes outdated:  
+The old wiki, has more content, but is sometimes outdated:
 [https://magiclantern.fandom.com/wiki/Magic_Lantern_Firmware_Wiki](https://magiclantern.fandom.com/wiki/Magic_Lantern_Firmware_Wiki)
 
-The new wiki, it's nicer...  but it's far from complete:  
+The new wiki, it's nicer...  but it's far from complete:
 [https://wiki.magiclantern.fm/](https://wiki.magiclantern.fm/)
 
 # Building Magic Lantern
-The build system is make, and has a lot of inherited complexity.  Most of this can be ignored.  Assuming you want to work on an individual cam, the 99D, and your machine has 16 cores / threads, this is all that is needed:
+The build system is make, and has a lot of inherited complexity. Most of this
+can be ignored.  Assuming you want to work on an individual cam, the 99D, and
+your machine has 16 cores / threads, this is all that is needed:
 
-  - clone this repo
-  - be in platform/99D
-  - run: `make -j16 zip`
-  - (possibly, fix your build environment because we don't check for pre-requisites, then repeat the previous step...)
-  - unzip the result onto a prepared card
+- clone this repo
+- be in platform/99D
+- run: `make -j16 zip`
+- (possibly, fix your build environment because we don't check for
+  pre-requisites, then repeat the previous step...)
+- unzip the result onto a prepared card
 
-If using qemu for testing, the unzip step is not required, qemu run script will do this for you.
+If using qemu for testing, the unzip step is not required, qemu run script
+will do this for you.
 
-The build system is currently tested on Linux, but is expected to work on Windows (via WSL) and Mac. Try not to obviously break this.  If we have a volunteer to test on other systems we could make this guarantee stronger.
+The build system is currently tested on Linux, but is expected to work on
+Windows (via WSL) and Mac. Try not to obviously break this. If we have a
+volunteer to test on other systems we could make this guarantee stronger.
 
 # Source control / repo conventions
-We use git, currently hosted on Github, but we don't tie things strongly to Github.  Github specific features can be used if sensible, if the purpose also works locally (e.g., a test system could use Actions, but the same tests should be able to run locally too).
+We use git, currently hosted on GitHub, but we don't tie things strongly to
+GitHub. GitHub-specific features can be used if sensible, if the purpose also
+works locally (e.g., a test system could use Actions, but the same tests should
+be able to run locally too).
 
 ### Licensing
-Magic Lantern is GPLv2 licensed.  Any contributed code or code changes must be licensed in a compatible way.  If in doubt, ask the maintainers of ML.
+Magic Lantern is GPLv2 licensed.
+Any contributed code or code changes must be licensed in a compatible way.
+If in doubt, ask the maintainers of ML.
 
 ### Workflow
 Getting a change to this repo looks like this:
+- fork the repo
+- branch from "dev", make your changes
+- make a PR against original repo
 
-  - fork the repo
-  - branch from "dev", make your changes
-  - make a PR against original repo
+When you're ready for PR / merge to dev, you should first check dev hasn't had
+any changes since you branched: dev is updated via merge --ff-only.  If dev is
+updated before your PR is merged you are responsible for rebasing from dev
+before the PR can be accepted.
 
-When you're ready for PR / merge to dev, you should first check dev hasn't had any changes since you branched: dev is updated via merge --ff-only.  If dev is updated before your PR is merged you are responsible for rebasing from dev before the PR can be accepted.
-
-This gives us a very clean history on dev.  Conflicts are rare because pace of commits is low.
+This gives us a very clean history on dev.
+Conflicts are rare because pace of commits is low.
 
 ### Commits
-Commit messages should explain why the change was made, not simply what change happened.  If it's a non trivial change, use a short (one line) and a long message (as much as you want) to give a good explanation.
+Commit messages should explain why the change was made, not simply what change
+happened. If it's a non trivial change, use a short (one line) and a long
+message (as much as you want) to give a good explanation.
 
-E.g.:  
+e.g.:
 [https://github.com/reticulatedpines/magiclantern_simplified/commit/1d4363410031a7efb29e0aff24bc2cafd2a2dc1c](https://github.com/reticulatedpines/magiclantern_simplified/commit/1d4363410031a7efb29e0aff24bc2cafd2a2dc1c)
 
-Most commits relate to a subarea.  Use a prefix on the message to indicate this.  E.g.:  
-"5D4: fix misclassification of this cam as Dual Digic"  
-"compositor: SX740 support"  
+Most commits relate to a subarea. Use a prefix on the message to indicate this.
+e.g.:
+"5D4: fix misclassification of this cam as Dual Digic"
+"compositor: SX740 support"
 "gcc warnings: fix 5D2 bad intptr_t usage"
 
-Give maintainers enough information so that they can understand the purpose and scope of the change and test correctness.
+Give maintainers enough information so that they can understand the purpose and
+scope of the change and test correctness.
 
-Commits should hold a self-contained unit of work.  This can cover a change in multiple files, but should not include multiple unrelated changes in one commit.  If working on a large feature, avoid single large commits where possible; build up the feature you're working on in pieces.
+Commits should hold a self-contained unit of work.
+This can cover a change in multiple files, but should not include multiple
+unrelated changes in one commit.  If working on a large feature, avoid single
+large commits where possible; build up the feature you're working on in pieces.
 
-If you find a bug or mistake in your work, don't have one commit with the mistake and one undoing it: remove both commits before attempting PR.
+If you find a bug or mistake in your work, don't have one commit with the
+mistake and one undoing it: remove both commits before attempting PR.
 
 ### Code comments
-Our code is not, and cannot, be self-documenting.  In many places the code depends on behaviour of the camera, which is not documented at all.  Do not be afraid of long comments when you are explaining things outside of the code.
+Our code is not, and cannot, be self-documenting.
+In many places, the code depends on the behaviour of the camera, which is not
+documented at all. Do not be afraid of long comments when you are explaining
+things outside the code.
 
-Give enough information so that your code can be understood and tested by someone else.
+Give enough information so that your code can be understood and tested by
+someone else.
 
-E.g.:  
-"Here we sleep for 50ms to give the mirror time to settle, without this the 99D errors with MechERR NG on UART".
+e.g.:
+"Here we sleep for 50ms to give the mirror time to settle, without this the
+99D errors with MechERR NG on UART".
 
 ### Making good changes
 Changes intended for one cam must not break things for other cams.
 
-It is okay if a change is visible for only those cameras it works on, and hidden for others.  It's better if it works on all cams.
+It is okay if a change is visible for only those cameras it works on,
+and hidden for others. It's better if it works on all cameras.
 
-Changes should be "safe enough".  Give people fair warning, and disable dangerous things by default. ML is inherently experimental, some risk is allowed.  Test to a sensible degree, relative to the changes being made.
+Changes should be "safe enough".
+Give people fair warning, and disable dangerous things by default. ML is
+inherently experimental, some risk is allowed.  Test to a sensible degree,
+relative to the changes being made.
 
 Some examples:
+- Changes to ML GUI can be tested in Qemu and don't require tests on
+  physical cams (still nice if you have the time!).
+- Changes involving interactions with camera hardware will sometimes emulate
+  okay in Qemu but must also be tested on physical cameras, the emulation
+  may not be representative.
+- Changes to ML bootloader must be tested extensively in Qemu first and on
+  physical cams covering multiple Digic generations.  Problems here can be
+  serious and leave the user with no useful feedback.
 
-  - Changes to ML GUI can be tested in Qemu and don't require tests on physical cams (still nice if you have the time!).
-  - Changes involving interactions with camera hardware will sometimes emulate okay in Qemu but must also be tested on physical cameras, the emulation may not be representative.
-  - Changes to ML bootloader must be tested extensively in Qemu first and on physical cams covering multiple Digic generations.  Problems here can be serious and leave the user with no useful feedback.
+When working in risky areas, consider leaving your code disabled by default,
+with a flag or similar. This means you can easily enable locally, but anyone
+accessing your public work will be safe by default. Enable in the repo only
+after reasonable testing has occurred.
 
-When working in risky areas, consider leaving your code disabled by default, with a flag or similar.  This means you can easily enable locally, but anyone accessing your public work will be safe by default.  Enable in the repo only after reasonable testing has occured.
-
-The goal here is that someone finding this repo won't break their cam even if they don't talk to us first to get instructions.
+The goal here is that someone finding this repo won't break their cam even if
+they don't talk to us first to get instructions.
 
 Tests to run before commits:
-
-  - "make zip" in platform dir must succeed: all enabled cams should build
-  - no new compiler warnings
+- "make zip" in platform dir must succeed: all enabled cams should build
+- no new compiler warnings
 
 Tests to run before merges to dev:
-
-  - as above, plus:
-  - completed, user-accessible features should be tested extensively on a physical cam
-  - (qemu tests when they exist)
+- as above, plus:
+- completed, user-accessible features should be tested extensively on a
+  physical cam
+- (qemu tests when they exist)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ detection, focus assist tools, manual audio controls much more.
 
 For more details on Magic Lantern please see [http://www.magiclantern.fm/](http://www.magiclantern.fm/)
 
-There is a sibling repo for our patched version of Qemu that adds support
-for emulating camera ROMs. This allows testing without access to a physical
-camera, and automating tests across a suite of cameras.  
-https://github.com/reticulatedpines/qemu-eos  
-https://github.com/reticulatedpines/qemu-eos/tree/qemu-eos-v4.2.1 (current ML team supported branch)
+There is a sibling repo ([reticulatedpines/qemu-eos](https://github.com/reticulatedpines/qemu-eos)) for our patched version of
+Qemu that adds support for emulating camera ROMs. This allows testing without
+access to a physical camera, and automating tests across a suite of cameras.
+
+The current ML team supported branch is [qemu-eos-v4.2.1](https://github.com/reticulatedpines/qemu-eos/tree/qemu-eos-v4.2.1).

--- a/developer_guide/02_00_hardware.md
+++ b/developer_guide/02_00_hardware.md
@@ -1,61 +1,100 @@
-
 # Hardware
 
 ## Overview
+Each camera can be considered to be a distributed system of processors and
+peripherals, able to communicate via interrupts, shared memory, or message
+passing. Not all devices are connected to all others.
 
-Each camera can be considered to be a distributed system of processors and peripherals, able to communicate via interrupts, shared memory, or message passing.  Not all devices are connected to all others.  Not all communication options are applicable to all devices; you must use what works.
+Not all communication options are applicable to all devices;
+you must use what works.
 
-Our knowledge of what devices exist is incomplete.  Our knowledge of what devices can do is limited.  This section will try not to mislead you, but it is bound to contain incomplete information, and likely to contain incorrect information.
+Our knowledge of what devices exist is incomplete.
+Our knowledge of what devices can do is limited.
+
+This section will try not to mislead you, but it is bound to contain incomplete
+information, and likely to contain incorrect information.
 
 ### Digic
+Digic (officially: DiG!C) is the main ASIC for Canon cameras.
 
-Digic (officially: DiG!C) is the main ASIC for Canon cameras.  This contains one or more ARM cores, which run the primary OS, and many peripherals, including DSPs, high precision timers, etc.
+This contains one or more ARM cores, which run the primary OS, and many
+peripherals, including DSPs, high precision timers, etc.
 
-Digic exists in many generations, with ML having good support for Digic 4 and 5.  There is no generation 9, this was skipped in preference for the term Digic X.  ML support for generations 6 and 7 has had some success, gens 8 and X have limited support with undiagnosed bugs making stable builds not yet possible.
+Digic exists in many generations, with ML having good support for Digic 4 and 5.
+There is no generation 9, this was skipped in preference for the term Digic X.
 
-This document may use D4 to indicate Digic 4, or D678 to indicate any generation from 6 to 8, inclusive - or other similar constructions.
+ML support for generations 6 and 7 has had some success, gens 8 and X have
+limited support with undiagnosed bugs making stable builds not yet possible.
+
+This document may use D4 to indicate Digic 4, or D678 to indicate any generation
+from 6 to 8, inclusive - or other similar constructions.
 
 Also see:\
 [https://en.wikipedia.org/wiki/DIGIC](https://en.wikipedia.org/wiki/DIGIC)\
 [https://wiki.magiclantern.fm/digic](https://wiki.magiclantern.fm/digic)
 
 ### Main CPU(s)
+The main CPU, from an ML perspective, is termed the ICU. Our code runs here. 
+A lot of DryOS code runs here, also.
+An important secondary CPU is termed the MPU. An approximate split of their
+duties is that the ICU handles UI and CPU intensive tasks, while the MPU handles
+low-level tasks such as battery management, switch and button handling.
+In some senses, the MPU is the primary CPU: it is responsible for detecting
+power-on events and bringing the ICU up. The MPU is also responsible for turning
+the camera off should e.g., the battery door be opened.
 
-The main CPU, from an ML perspective, is termed the ICU.  Our code runs here.  A lot of DryOS code runs here, also.  An important secondary CPU is termed the MPU.  An approximate split of their duties is that the ICU handles UI and CPU intensive tasks, while the MPU handles low-level tasks such as battery management, switch and button handling.  In some senses, the MPU is the primary CPU: it is responsible for detecting power on events and bringing the ICU up.  The MPU is also responsible for turning the cam off should e.g., the battery door be opened.
-
-There are three main families of ARM used across Digic gens that we care about.  D45 uses ARMv5TE.  D6 uses ARMv7-R.  This has a Memory Protection Unit (MPU!  But not the same MPU as above).  D78X use ARMv7-A and have a full MMU.
+There are three main families of ARM used across Digic gens that we care about.
+D45 uses ARMv5TE. D6 uses ARMv7-R. This has a Memory Protection Unit (MPU! But
+not the same MPU as above). D78X use ARMv7-A and have a full MMU.
 
 D45 are single core parts.
 
-D6 are less well understood.  There's a Master and Slave CPU, both ARMv7-R.  These might be on the same chip.
+D6 are less well understood. There's a Master and Slave CPU, both ARMv7-R.
+These might be on the same chip.
 
-D78X parts are true dual-core, with shared RAM.  They have ARM GIC and can communicate in a standard manner via interrupts.  In addition, DryOS provides at least two RPC mechanisms.
+D78X parts are true dual-core, with shared RAM.
+They have ARM GIC and can communicate in a standard manner via interrupts.
+In addition, DryOS provides at least two RPC mechanisms.
 
-Some cams are described by Canon as Dual Digic.  E.g. the 7D Mark II, which has two independent Digic 6 ASICs.  This probably makes it somewhat equivalent to a dual-socket, dual-core system.
+Some cams are described by Canon as Dual Digic.
+e.g. the 7D Mark II, which has two independent Digic 6 ASICs.
+This probably makes it somewhat equivalent to a dual-socket, dual-core system.
 
-Some cams have a secondary Digic, of a lower generation, used for a subset of tasks.  For example, the 1DX is D5, but uses a D4 for auto-exposure.
+Some cams have a secondary Digic, of a lower generation, used for a subset of
+tasks. For example, the 1DX is D5, but uses a D4 for auto-exposure.
 
-Lastly, and least important to ML, some Digic gens come in a normal and "+" variant.  E.g. the 5D Mark III is Digic 5+.  These plus variants don't seem to have extra capabilities, and are likely the same fundamental design, perhaps die-shrunk, and clocked higher.  From a processing power perspective this is important - Canon claims a 3x improvement between some plus and non-plus parts.  From a reverse engineering perspective the differences are minimal.
+Lastly, and least important to ML, some Digic gens come in a normal and "+"
+variant.  E.g. the 5D Mark III is Digic 5+.  These plus variants don't seem to
+have extra capabilities, and are likely the same fundamental design, perhaps
+die-shrunk, and clocked higher.  From a processing power perspective this is
+important - Canon claims a 3x improvement between some plus and non-plus parts.
+From a reverse engineering perspective the differences are minimal.
 
 Points of note:
-
 - All cams can run Thumb instructions
 - D45 can use cache locking to "edit" instructions in code ROM
 - D78X have MMU so can "edit" large regions of code ROM
 - D6 doesn't have a proven way to "edit" ROM
 
 ### Secondary processors
+There are further processors for specialised tasks.  Since these are utilised
+via APIs and / or message passing, their internals are poorly understood.
 
-There are further processors for specialised tasks.  Since these are utilised via APIs and / or message passing, their internals are poorly understood.
+Tasks that are performance critical (either throughput or latency) may run on
+some accelerator.  E.g., JPEG compression, video compression.  These are likely
+ASICs, though there are signs that FPGAs are used in some generations. Possibly,
+early implementations use FPGA, which are later converted to ASICs.
 
-Tasks that are performance critical (either throughput or latency) may run on some accelerator.  E.g., JPEG compression, video compression.  These are likely ASICs, though there are signs that FPGAs are used in some generations.  Possibly, early implementations use FPGA, which are later converted to ASICs.
-
-Cams with integrated networking typically delegate this to another part.  On D78X this is Xtensa ISA and internally named "Lime".  The ICU can command Lime, which, presumably, directly controls some WiFi SoC.
+Cams with integrated networking typically delegate this to another part. On D78X
+this is Xtensa ISA and internally named "Lime". The ICU can command Lime, which,
+presumably, directly controls some WiFi SoC.
 
 ### Other peripherals
+Not all devices are processors. There are many MMIO devices, critical to
+controlling the camera. Some are digital, e.g. the DMA controller. Some border
+on analog, e.g. there's a unit named ADTG which is believed to be a timing
+generator, used for controlling how the sensor is read out.
+Digital configuration, most likely controlling analog hardware.
 
-Not all devices are processors.  There are many MMIO devices, critical to controlling the camera.  Some are digital, e.g. the DMA controller.  Some border on analog, e.g. there's a unit named ADTG which is believed to be a timing generator, used for controlling how the sensor is read out.  Digital configuration, most likely controlling analog hardware.
-
-MMIO addresses are used by the ICU (and potentially other processors) to configure, control, or read information from, these peripherals.
-
-<div style="page-break-after: always; visibility: hidden"></div>
+MMIO addresses are used by the ICU (and potentially other processors) to
+configure, control, or read information from, these peripherals.

--- a/developer_guide/02_01_hardware.md
+++ b/developer_guide/02_01_hardware.md
@@ -1,19 +1,16 @@
-
 ### ICU
-
 Detailed information re ICU should go here.
 
 ### MPU
-
 ML relevant information re MPU goes here.
 
 ### JPCORE
-
 Do we have enough specific about JPCORE to justify a section?
 
 ### Lime
-
-Enough info about Lime to justify section?  Probably just barely, given the power hack for 200D.  Generally devs only need to care about the socket APIs.
+Enough info about Lime to justify section?
+Probably just barely, given the power hack for 200D.
+Generally devs only need to care about the socket APIs.
 
 ### DMA
 
@@ -32,27 +29,30 @@ by Canon to refer to something like image processing devices.
 XDMAC was first found by g3gg0 on 600D:\
 [https://groups.google.com/g/ml-devel/c/7EJwZIbLfbI](https://groups.google.com/g/ml-devel/c/7EJwZIbLfbI)
 
-On older cams XDMAC has 4 channels, with a struct configured at
-0xc0a1\_0000 + (0x10000 * chan\_index).  Details of the transfer are setup,
-then the control register is set, and the transfer starts.
+On older cams XDMAC has 4 channels, with a struct configured at 0xc0a1\_0000
++ (0x10000 * chan\_index).  Details of the transfer are setup, then the control
+register is set, and the transfer starts.
 
 Newer cams have more channels (200D has 8), and the MMIO address has moved,
 possibly to 0xc920\_0000 region, although this is not yet confirmed.
 
 Code working with this device can be clearly seen in dma\_memcpy().
 
-There are several APIs for accessing XDMAC, the one used in stubs is named "dma\_memcpy".
-This variant is blocking.  A variant exists that takes a CBR, for an async copy that signals when
-it completes.  Older ML docs discuss this variant, but current ML code doesn't use it.
+There are several APIs for accessing XDMAC, the one used in stubs is named
+"dma\_memcpy". This variant is blocking. A variant exists that takes a CBR,
+for an async copy that signals when it completes.  Older ML docs discuss this
+variant, but current ML code doesn't use it.
 
-When calling dma\_memcpy(), DMA setup code behaves differently depending on properties
-of the memory block for dst and/or src.  This may include whether the memory is
-Cacheable or Uncacheable, or alignment of the block.  The difference in performance
-can be significant, and which factors are most important vary by cam.
+When calling dma\_memcpy(), DMA setup code behaves differently depending on
+properties of the memory block for dst and/or src.  This may include whether the
+memory is Cacheable or Uncacheable, or alignment of the block.  The difference
+in performance can be significant, and which factors are most important vary
+by cam.
 
 XDMAC is not used much by ML, because EDMAC can do the same job, typically has a
-faster copy speed, and in addition, can be used efficiently for e.g. copying a cropped
-region during image capture, whereas XDMAC can only do simple linear copies.
+faster copy speed, and in addition, can be used efficiently for e.g. copying a
+cropped region during image capture, whereas XDMAC can only do simple linear
+copies.
 
 For reference, the struct starting at 0xc0a1\_0000 looks like this:
 
@@ -85,16 +85,17 @@ struct xdmac_mmio
 // dst and src addresses should be aligned to 0x20 with respect to each other.
 ```
 
-Please note that the comments and behaviour are not tested on all cams.  It is possible
-that some cams will use a different struct, or have different meanings for flags, different
-requirements for alignment of buffers, etc.
+Please note that the comments and behaviour are not tested on all cams.  It is
+possible that some cams will use a different struct, or have different meanings
+for flags, different requirements for alignment of buffers, etc.
 
 ### EDMAC
 
-EDMAC is the "Engine DMA Controller".  Unlike XDMAC, it can efficiently copy a sub-region, which
-represents a rectangular image, out of a larger area.  Imagine an image with black borders on
-all edges, stored linearly.  EDMAC can be configured to offset a series of copies by the size
-of the borders, allowing stripping out the borders at almost the full speed of the memory bus.
+EDMAC is the "Engine DMA Controller".  Unlike XDMAC, it can efficiently copy a
+sub-region, which represents a rectangular image, out of a larger area.  Imagine
+an image with black borders on all edges, stored linearly.  EDMAC can be
+configured to offset a series of copies by the size of the borders, allowing
+stripping out the borders at almost the full speed of the memory bus.
 Other operations are also possible.
 
 This is a Canon patented part, so the capabilities are well understood:\
@@ -103,7 +104,8 @@ This is a Canon patented part, so the capabilities are well understood:\
 A simplified version of figure 11a from the patent:
 ![EDMAC copy region](images/edmac_diagram.png){.wide}
 
-The configuration for a copy defines a set of tiles, via a struct defined in edmac.h:
+The configuration for a copy defines a set of tiles,
+via a struct defined in edmac.h:
 
 ```
 struct edmac_info
@@ -122,51 +124,54 @@ struct edmac_info
 };
 ```
 
-Tiles can overlap, or have gaps between them, this is controlled by the offset parameters,
-and is not shown on the simplified diagram.
+Tiles can overlap, or have gaps between them, this is controlled by the offset
+parameters, and is not shown on the simplified diagram.
 
-The most basic usage is copying a linear run of bytes, for this most fields can be left as 0,
-using xn and yn to define a "rectangle" of area equal to the required copy length.  More examples
-are given in section 6.
+The most basic usage is copying a linear run of bytes, for this most fields can
+be left as 0, using xn and yn to define a "rectangle" of area equal to the
+required copy length.  More examples are given in section 6.
 
 ### ADTG
 
-This is a custom part from Analog Devices, specialised for reading out analog image sensors.
-We don't know the exact part number, but a part that is likely somewhat similar has a datasheet here:
+This is a custom part from Analog Devices, specialised for reading out analog
+image sensors. We don't know the exact part number, but a part that is likely
+somewhat similar has a datasheet here:
 [https://www.analog.com/media/en/technical-documentation/data-sheets/AD9826.pdf]()
 
-Sensor data capture and amplification are done in the analog domain, fed to an ADC and the results
-placed in RAM for use by ICU.
+Sensor data capture and amplification are done in the analog domain, fed to an
+ADC and the results placed in RAM for use by ICU.
 
-The sensor is read by using precise, configurable timers to control how long to read
-each row, column, etc.
+The sensor is read by using precise, configurable timers to control how long to
+read each row, column, etc.
 
-The ADTG can be configured from the ICU, which allows the cam to select image size, ISO, etc.
-This happens by preparing a buffer with a sequence of command words, and calling a DryOS function
-to send to the ADTG.
+The ADTG can be configured from the ICU, which allows the cam to select image
+size, ISO, etc. This happens by preparing a buffer with a sequence of command
+words, and calling a DryOS function to send to the ADTG.
 
-Command words are 16 or 32 bit, depending on which cam and sub-part of the ADTG is being
-controlled.
+Command words are 16 or 32 bit, depending on which cam and sub-part of the ADTG
+is being controlled.
 
-ML docs sometimes talk about ADTG or CMOS "registers".  This is likely to be confusing terminology.
-To understand, you must know that the ADTG part has sub-parts that can be individually configured.
-These include, at least, a part dedicated to reading data from the CMOS sensor, an ADC, and
-various timers.  Historically, we've called out CMOS control separately, but called everything
-else "ADTG".  The "register" term is because some command words have a field for selecting
-a register internal to the ADTG.
+ML docs sometimes talk about ADTG or CMOS "registers".  This is likely to be
+confusing terminology. To understand, you must know that the ADTG part has
+sub-parts that can be individually configured. These include, at least, a part
+dedicated to reading data from the CMOS sensor, an ADC, and various timers.
+Historically, we've called out CMOS control separately, but called everything
+else "ADTG".  The "register" term is because some command words have a field
+for selecting a register internal to the ADTG.
 
 We use the ADTG for several tasks:
 - fine tuning FPS
-- selecting image capture size (this includes image displayed in LiveView, crop video)
+- selecting image capture size
+  (this includes image displayed in LiveView, crop video)
 - dual ISO captures
 
-There have been some attempts to reduce rolling shutter, increase FPS etc - there is
-much more exploration left to be done in this area.
+There have been some attempts to reduce rolling shutter, increase FPS etc
+- there is much more exploration left to be done in this area.
 
-You can use the module adtglog2 to log command data to card, in a human readable format
-that is similar across different cams.  This helps greatly when porting a feature from
-a well supported cam to a new cam.  The command formats tend to change per sensor gen,
-which is only weakly linked to Digic gen.
+You can use the module adtglog2 to log command data to card, in a human readable
+format that is similar across different cams.  This helps greatly when porting a
+feature from a well supported cam to a new cam. The command formats tend to
+change per sensor gen, which is only weakly linked to Digic gen.
 
 Example command data, logged from a 6D2:
 ```
@@ -174,19 +179,17 @@ CMOS_write, time: 24461,  LR: e0302d23, buf_addr: 415a7ae8
     data: 0d03a440 10717220 21a30100 3c120000 4476520a 50000010 60000021 72000000
           80000008 98210ba0 a0000000 d000e9f1 e00009f1 ffffffff
 ```
-Most of the content here is not understood.  The first word is partially understood,
-this commands CMOS register 0xd to sample the sensor at ISO 1600.  The last word
-signals the end of the command buffer; this is always -1 in whatever width the
-sub-part expects.  `0x0d03a110` would mean ISO 200.
+Most of the content here is not understood.  The first word is partially
+understood, this commands CMOS register 0xd to sample the sensor at ISO 1600.
+The last word signals the end of the command buffer; this is always -1 in
+whatever width the sub-part expects.  `0x0d03a110` would mean ISO 200.
 
-ML can modify behaviour of this command so that e.g. `0x0d03a040` is sent, leading
-to alternate lines being sampled at ISO 100 and 1600.
+ML can modify behaviour of this command so that e.g. `0x0d03a040` is sent,
+leading to alternate lines being sampled at ISO 100 and 1600.
 
-Finding these commands is not too hard; start logging, then exercise the cam
-to, e.g., change ISO, and take a picture (changing a setting without using related
-functionality may not send the command).  Try two different ISOs, then check the log
-for differences.
+Finding these commands is not too hard; start logging, then exercise the cam to,
+e.g., change ISO, and take a picture (changing a setting without using related
+functionality may not send the command).  Try two different ISOs, then check the
+log for differences.
 
 D45 cams seem to use NZR encoding.
-
-<div style="page-break-after: always; visibility: hidden"></div>

--- a/developer_guide/03_00_architecture.md
+++ b/developer_guide/03_00_architecture.md
@@ -1,18 +1,25 @@
-
 # Magic Lantern Architecture
 
 ## Running Magic Lantern code
 
 How do we convince cameras to run our code?
 
-DryOS has functionality, disabled by default, to load and run code from a file named autoexec.bin.
-This is presumed to be an engineering or testing function.
+DryOS has functionality, disabled by default, to load and run code from a file
+named autoexec.bin. This is presumed to be an engineering or testing function.
 
 ### Enabling the camera boot flag
 
-Before DryOS will attempt to run autoexec.bin, a flag must be set in the flash mem / ROM.  There are multiple routes to achieve this, the most common is using a FIR file created by us for this purpose.  When the user triggers the standard Canon firmware update routine, instead of running update code, our FIR file toggles the boot flag.
+Before DryOS will attempt to run autoexec.bin, a flag must be set in the flash
+mem / ROM.  There are multiple routes to achieve this, the most common is using
+a FIR file created by us for this purpose.  When the user triggers the standard
+Canon firmware update routine, instead of running update code, our FIR file
+toggles the boot flag.
 
-This is the only direct persistent change we make.  Other persistent changes are made indirectly, since DryOS saves various settings ("properties"), and we may alter their content.  Saving incorrect properties can make a cam unresponsive until they are reset, which may not be practical for the average user - try to never have this occur!
+This is the only direct persistent change we make.  Other persistent changes are
+made indirectly, since DryOS saves various settings ("properties"), and we may
+alter their content.  Saving incorrect properties can make a cam unresponsive
+until they are reset, which may not be practical for the average user - try to
+never have this occur!
 
 ### Making a card bootable
 
@@ -20,23 +27,50 @@ Boot disks have a few magic bytes set, see contrib/make-bootable for details.
 
 ### autoexec.bin contains Magic Lantern
 
-With the camera boot flag set, DryOS will look for a boot disk. Behaviour is as follows:
+With the camera boot flag set, DryOS will look for a boot disk.
+Behaviour is as follows:
 
-- If a boot disk is not found, a normal boot occurs.  Therefore, if you use a card without Magic Lantern installed, the camera will behave as normal.
+- If a boot disk is not found, a normal boot occurs.  Therefore, if you use a
+  card without Magic Lantern installed, the camera will behave as normal.
 
-- If a boot disk is found, but there is no autoexec.bin, the camera will hang.  This is deliberate error handling.  The cam must be powered down and battery removed.  This means if you simply delete ML content from a card, a boot flag enabled camera can appear broken, when it isn't.  Formatting the card removes the boot disk magic.
+- If a boot disk is found, but there is no autoexec.bin, the camera will hang.
+  This is deliberate error handling.  The cam must be powered down and battery
+  removed.  This means if you simply delete ML content from a card, a boot flag
+  enabled camera can appear broken, when it isn't.  Formatting the card removes
+  the boot disk magic.
 
-- If a boot disk is found, and autoexec.bin exists on the root of the filesystem, the contents are copied to address 0x80\_0000 and control is transferred to that address.
+- If a boot disk is found, and autoexec.bin exists on the root of the
+  filesystem, the contents are copied to address 0x80\_0000 and control is
+  transferred to that address.
 
-The final executable output of the build system for ML is autoexec.bin.  However, our code runs before the OS has started, which includes hardware initialisation.  We want DryOS to do the hard work of bringing the camera fully up.  We inject enough code so that later on we maintain visibility and control.
+The final executable output of the build system for ML is autoexec.bin. However,
+our code runs before the OS has started, which includes hardware initialisation.
+
+We want DryOS to do the hard work of bringing the camera fully up.
+We inject enough code so that later on we maintain visibility and control.
 
 ### Boot process under ML in detail
 
-It's important to understand how the boot process works if you're interested in porting ML to a new cam, since debugging these early stages is hard without a good mental model.  If you're working on a well supported cam, this is less relevant, since dev work is much closer to "normal": you're writing code that will run at the application layer, on top of a running OS.
+It's important to understand how the boot process works if you're interested in
+porting ML to a new cam, since debugging these early stages is hard without a
+good mental model.
+If you're working on a well supported cam, this is less relevant, since dev work
+is much closer to "normal": you're writing code that will run at the application
+layer, on top of a running OS.
 
-DryOS always starts execution at offset 0 of autoexec.bin, and this always occurs at 0x80\_0000 in ram.  This code is in reboot.c, located via symbol name "\_start".  The early asm code does some safety checks, and if they pass transfers control to cstart(), in the same file.
+DryOS always starts execution at offset 0 of autoexec.bin, and this always
+occurs at 0x80\_0000 in ram.  This code is in reboot.c, located via symbol name
+"\_start".  The early asm code does some safety checks, and if they pass
+transfers control to cstart(), in the same file.
 
-cstart() checks that we're running on the expected cam, erroring if not.  Assuming success, we copy a large portion of autoexec.bin to another location, because the 0x80\_0000 area is used for multiple purposes - later on, DryOS will re-use this region and delete our initial code.  The destination for the copy is cam specific, it must be somewhere safe that the OS won't touch.  Finding such a location is made easier by the fact that we can modify OS initialisation, often we can steal memory from the OS heap, meaning ML will be located before or after heap space.
+cstart() checks that we're running on the expected cam, erroring if not. 
+Assuming success, we copy a large portion of autoexec.bin to another location,
+because the 0x80\_0000 area is used for multiple purposes - later on, DryOS will
+re-use this region and delete our initial code.  The destination for the copy is
+cam specific, it must be somewhere safe that the OS won't touch.  Finding such a
+location is made easier by the fact that we can modify OS initialisation, often
+we can steal memory from the OS heap, meaning ML will be located before or after
+heap space.
 
 That copy happens here:
 
@@ -48,25 +82,55 @@ That copy happens here:
      );
 ```
 
-blob\_start and blob\_end are addresses that cover a region in autoexec.bin.  The build system places "magiclantern.bin" in this region, which is a stripped version of "magiclantern" - which is a normal ELF binary.  This allows us to have a compact representation in the limited camera memory, while having a relatively normal build process, with usable debug symbols.
+blob\_start and blob\_end are addresses that cover a region in autoexec.bin.
+The build system places "magiclantern.bin" in this region, which is a stripped
+version of "magiclantern" - which is a normal ELF binary.  This allows us to
+have a compact representation in the limited camera memory, while having a
+relatively normal build process, with usable debug symbols.
 
-We then do a small amount of hardware specific initialisation, found via reverse engineering normal DryOS startup.  Finally, autoexec.bin transfers control to RESTARTSTART; the address in mem of our copied magiclantern.bin.  RESTARTSTART is defined in platform/XXXD.YYY/Makefile.  It's used in src/magiclantern.lds.S when linking magiclantern.
+We then do a small amount of hardware specific initialisation, found via reverse
+engineering normal DryOS startup.  Finally, autoexec.bin transfers control to
+RESTARTSTART; the address in mem of our copied magiclantern.bin.
 
-Which code is at the start of magiclantern.bin and therefore called as RESTARTSTART is defined by entry.S - a function called copy\_and\_restart().  We're now running from the new location and the copy of autoexec.bin at 0x80\_0000 is no longer needed.
+RESTARTSTART is defined in platform/XXXD.YYY/Makefile.
+It's used in src/magiclantern.lds.S when linking magiclantern.
 
-There are multiple source files containing a copy\_and\_restart() function, but only one is used per cam.  Selection occurs as part of the per platform config, e.g.:
+Which code is at the start of magiclantern.bin and therefore called as
+RESTARTSTART is defined by entry.S - a function called copy\_and\_restart().
+
+We're now running from the new location and the copy of
+autoexec.bin at 0x80\_0000 is no longer needed.
+
+There are multiple source files containing a copy\_and\_restart() function, but
+only one is used per cam.
+Selection occurs as part of the per platform config, e.g.:
 
 ```
     platform/60D.111/Makefile:ML_BOOT_OBJ   = boot-d45-ch.o
 ```
 
-Therefore for 60D, boot-d45-ch.c will be used.  The code is split like this as there are multiple different ways to reserve space for ML, depending on memory layout and physical capabilities of a cam.
+Therefore for 60D, boot-d45-ch.c will be used.  The code is split like this as
+there are multiple different ways to reserve space for ML, depending on memory
+layout and physical capabilities of a cam.
 
-copy\_and\_restart() has the job of making a copy of Canon's early init code in ram, then modifying it for our purposes.  This is where we inject ML functionality.  We must also fixup code broken by the relocation (e.g. PC relative addressing).  We then transfer to this code, allowing DryOS to initialise but with our modifications.
+copy\_and\_restart() has the job of making a copy of Canon's early init code in
+RAM, then modifying it for our purposes.  This is where we inject ML
+functionality.  We must also fixup code broken by the relocation (e.g. PC
+relative addressing).  We then transfer to this code, allowing DryOS to
+initialise but with our modifications.
 
-The precise modifications vary a little per cam, but the common idea is that DryOS initialisation uses pointers to various functions and data structures; we have substituted our own.  Part of this ensures that the memory region we copied magiclantern.bin to is outside of the memory DryOS will use - we tell the OS it has a smaller region to work with, and ML fits inside the "missing" memory.
+The precise modifications vary a little per cam, but the common idea is that
+DryOS initialisation uses pointers to various functions and data structures;
+we have substituted our own.  Part of this ensures that the memory region we
+copied magiclantern.bin to is outside of the memory DryOS will use - we tell
+the OS it has a smaller region to work with, and ML fits inside the
+"missing" memory.
 
-If you look at this code you may see the name ROMBASEADDR.  It's worth noting this is a misleading name.  It's nothing to do with the base address of the rom, it is in fact the start address of the main firmware; the code after the bootloader, responsible for bringing up the OS.  While this has been renamed to MAIN_FIRMWARE_ADDR, some references may remain.
+If you look at this code you may see the name ROMBASEADDR.  It's worth noting
+this is a misleading name.  It's nothing to do with the base address of the rom,
+it is in fact the start address of the main firmware; the code after the
+bootloader, responsible for bringing up the OS.  While this has been renamed to
+MAIN_FIRMWARE_ADDR, some references may remain.
 
 We've got out of the bootloader!  Things are simpler from now on.
 
@@ -74,8 +138,7 @@ To summarise:
 
 - autoexec.bin loads at 0x80\_0000, running code from reboot.c
 - magiclantern.bin, contained in autoexec.bin, copied to a safe location in ram
-- RESTARTSTART() called, which is an alias for copy\_and\_restart(), from boot-XX.c
+- RESTARTSTART() called, which is an alias for
+  copy\_and\_restart(), from boot-XX.c
 - Canon init code relocated to a safe writable location, modified to inject ML
 - Modified Canon init code called: DryOS initialises with ML injected
-
-<div style="page-break-after: always; visibility: hidden"></div>

--- a/developer_guide/04_00_building_ML.md
+++ b/developer_guide/04_00_building_ML.md
@@ -2,13 +2,20 @@
 
 ## Overview
 
-The Magic Lantern build system is a fairly standard GNU Make system, with some calls out to Python 3 scripts.  It should be safe to use parallel make jobs, e.g. `make -j6`.
+The Magic Lantern build system is a fairly standard GNU Make system, with some
+calls out to Python 3 scripts.  It should be safe to use parallel make jobs,
+e.g. `make -j6`.
 
 People have succeeded in building ML on Windows (via WSL), OSX, and Linux.
 
-The standard output is a zip file, that can be extracted to a memory card ready to run on a camera.  This contains a variety of assets, such as bitmap images, fonts, Lua scripts.  It also includes binary modules, optional components that can be selected to load by the user at runtime.  Finally, there is one primary binary, always named autoexec.bin.
+The standard output is a zip file, that can be extracted to a memory card ready
+to run on a camera.  This contains a variety of assets, such as bitmap images,
+fonts, Lua scripts.  It also includes binary modules, optional components that
+can be selected to load by the user at runtime.  Finally, there is one primary
+binary, always named autoexec.bin.
 
-Autoexec.bin is a name checked for by DryOS, and as explained in section 3, can be used to load our code (given some other conditions being true).
+Autoexec.bin is a name checked for by DryOS, and as explained in section 3, can
+be used to load our code (given some other conditions being true).
 
 There are three globally important files:
 ```
@@ -29,44 +36,57 @@ There is also a set of per cam files, one per cam, e.g.:
 cd platform/5D3.123
 make -j6
 ```
-This builds for 5D3 only, and will also trigger a build of all modules as required.
-6 jobs are used, typically speed-up is high up to the number of cores on the system, and still useful up to the number of threads.
-Running `make clean` here only cleans this cam, not modules.
-Build output is produced in `platform/5D3.123/build`, the main file being `magiclantern.zip`.
+This builds for 5D3 only, and will also trigger a build of all modules as
+required. 6 jobs are used, typically speed-up is high up to the number of cores
+on the system, and still useful up to the number of threads.
+
+Running `make clean` here only cleans this cam, not modules. Build output is
+produced in `platform/5D3.123/build`, the main file being `magiclantern.zip`.
 
 
 ```
 cd platform
 make -j6
 ```
-This builds for all cams listed in the ML\_CAMS var inside `platform/Makefile` (essentially, all cams known to work well; the default set of cams to produce builds for).
-Running `make clean` here cleans `platform/build` and all per cam build dirs.  Modules are not cleaned.
-Build output is produced in `platform/build`.
+This builds for all cams listed in the ML\_CAMS var inside `platform/Makefile`
+(essentially, all cams known to work well; the default set of cams to produce
+builds for).
 
+Running `make clean` here cleans `platform/build` and all per cam build dirs.
+Modules are not cleaned. Build output is produced in `platform/build`.
 
 ```
 cd modules/bench
 make -j6
 ```
-This builds the benchmark module only.  Running `make clean` here cleans only this module.
-Output goes to `modules/bench/build/`.
-
+This builds the benchmark module only.  Running `make clean` here cleans only
+this module. Output goes to `modules/bench/build/`.
 
 ```
 cd modules
 make -j6
 ```
-This builds all modules, but no cams.  Running `make clean` here cleans `build/` and all module build dirs.
-Output goes to `modules/build/`.
+This builds all modules, but no cams.  Running `make clean` here cleans `build/`
+and all module build dirs. Output goes to `modules/build/`.
 
 
 ### Environment variables
 
-The build system can produce different kinds of builds based on environment variables.  This can be a confusing pattern.  Work in 2024 reduced the number of available env vars, a few relevant ones remain:
+The build system can produce different kinds of builds based on environment
+variables.  This can be a confusing pattern.  Work in 2024 reduced the number of
+available env vars, a few relevant ones remain:
 
-`CONFIG_QEMU`: if set to y, various fixups to make Magic Lantern code work better in Qemu are performed, as well as extra debugging statements only visible in Qemu.  These builds *will not* run on physical cams.  They will typically hang the cam until battery is removed.  The extra debug output is very useful when diagnosing ML loader problems in qemu, if you're working in this area it's recommended you always run such tests before making a build for a physical cam.
+`CONFIG_QEMU`: if set to y, various fixups to make Magic Lantern code work
+better in Qemu are performed, as well as extra debugging statements only visible
+in Qemu.  These builds *will not* run on physical cams.  They will typically
+hang the cam until battery is removed.  The extra debug output is very useful
+when diagnosing ML loader problems in qemu, if you're working in this area it's
+recommended you always run such tests before making a build for a physical cam.
 
-`FATAL_WARNINGS`: if set to y, compiler warnings are elevated to errors.  Good for dev work.  It is expected that all supported cams and modules will compile with this setting.  If not, a bug can be raised and it will be fixed (assuming the build environment was sane).
+`FATAL_WARNINGS`: if set to y, compiler warnings are elevated to errors.  Good
+for dev work.  It is expected that all supported cams and modules will compile
+with this setting.  If not, a bug can be raised and it will be fixed (assuming
+the build environment was sane).
 
 Thus, to use both options and build for one cam:
 ```
@@ -74,6 +94,7 @@ cd platform/5D3.123
 make CONFIG_QEMU=y FATAL_WARNINGS=y -j6
 ```
 
-Which env vars were used for a build are not tracked as build dependencies.  This means if you change the options in use, you must manually run `make clean` over the relevant parts.  If you don't, you may have stale binary components, which can lead to dangerous behaviour.
-
-<div style="page-break-after: always; visibility: hidden"></div>
+Which env vars were used for a build are not tracked as build dependencies. 
+This means if you change the options in use, you must manually run `make clean`
+over the relevant parts.  If you don't, you may have stale binary components,
+which can lead to dangerous behaviour.

--- a/developer_guide/06_00_adding_features.md
+++ b/developer_guide/06_00_adding_features.md
@@ -1,4 +1,3 @@
-
 # Feature Implementation:<br>Details and Walkthroughs
 
 ## Enabling a simple feature
@@ -6,5 +5,3 @@
 This should be a walkthrough on feature flags, where they live,
 then how to check usage in code, find required dependencies,
 fix and test as required.
-
-<div style="page-break-after: always; visibility: hidden"></div>

--- a/developer_guide/06_01_adding_features.md
+++ b/developer_guide/06_01_adding_features.md
@@ -2,57 +2,68 @@
 
 _The following is rough notes only and needs re-working_
 
-"Channel": DryOS holds a global array, each element holding an EDMAC register and associated ModeInfo, e.g.:
+"Channel": DryOS holds a global array, each element holding an EDMAC register
+and associated ModeInfo, e.g.:
+
 uint D0004100h channel\_addr
 uint 2C05h     ModeInfo
 
-Each element is a "channel" (Digic >= 8 calls these "ports").  The channel\_addr values are often
-laid out in groups, evenly separated by 0x100.  They can jump by large amounts between groups.
-Presumably the EDMAC unit itself has more registers than channels assigned to DryOS for EDMAC.
+Each element is a "channel" (Digic >= 8 calls these "ports"). The channel\_addr
+values are often laid out in groups, evenly separated by 0x100. They can jump
+by large amounts between groups.
 
-On 200D, the channel array starts at 0x66264 and holds 0x35 elements.  I call this DmacInfo\_global.
-Many EDmac functions ref this array, including ConnectReadEDmac().  Functions often do a size check
-early on to ensure they're not going out of bounds.  Max channel index on 200D is 0x34.
+Presumably the EDMAC unit itself has more registers than channels assigned to
+DryOS for EDMAC.
+
+On 200D, the channel array starts at 0x66264 and holds 0x35 elements.
+I call this DmacInfo\_global. Many EDmac functions ref this array, including
+ConnectReadEDmac(). Functions often do a size check early on to ensure they're
+not going out of bounds. Max channel index on 200D is 0x34.
 
 "Resources": these are in essence devices that can be utilised via EDMAC.  
 Code often calls these Engine Resources.  "Engine" seems to mean something
 like "hardware devices accessed via EDMAC".
 
-The top-level struct for Resources I call ResourceInfo\_global.  This is indexed by blockNum,
-on 200D, max of 0x37.  Size is 0x1b8 total, 0x37 size 8 elements; two pointers each.
-On 200D, 0x10998 is a pointer to this global.  This represents "blocks" of "entries";
-each block is some distinct category or purpose.  Some purposes are known:
-ResourceInfo\_global[0] holds EDMAC resources designated for writes, 1 is for reads,
-2 is read-write, and so is 3.  Possibly 2 and 3 are different directions, RW vs WR,
-which could explain why there are separate groups.
+The top-level struct for Resources I call ResourceInfo\_global. This is indexed
+by blockNum, on 200D, max of 0x37. Size is 0x1b8 total, 0x37 size 8 elements;
+two pointers each. On 200D, 0x10998 is a pointer to this global. This represents
+"blocks" of "entries"; each block is some distinct category or purpose. Some
+purposes are known: ResourceInfo\_global[0] holds EDMAC resources designated for
+writes, 1 is for reads, 2 is read-write, and so is 3.  Possibly 2 and 3 are
+different directions, RW vs WR, which could explain why there are separate
+groups.
 
-ML *inconsistently* refers to groups 2 and 3 as "connections".  So, when old code notes or docs
-mentions an EDMAC connection, this *may* be referring to getting a RW channel via this mechanism.
-Sometimes, 2 is called "write connections", 3 "read connections".
+ML *inconsistently* refers to groups 2 and 3 as "connections".  So, when old
+code notes or docs mentions an EDMAC connection, this *may* be referring to
+getting a RW channel via this mechanism. Sometimes, 2 is called
+"write connections", 3 "read connections".
 
-As noted, ResourceInfo\_global is an array of pointer pairs.  Each array element represents
-a block, but a block contains nothing but entries.  Each pointer has type ResInfo\_entry \*,
-the first is entry\_prev, the second entry\_next.  Canon code has a slightly odd trick,
-where the prev pointer of the first element in the list, and the next pointer of the last element,
-point to the pointer-pair in ResourceInfo\_global.  This isn't a valid ResInfo\_entry, so when
-walking the list you must check the pointer address before accessing ResInfo\_entry fields.
-This also means that a block containing no entries will consist of two pointers both pointing
-to the address of the first pointer.
+As noted, ResourceInfo\_global is an array of pointer pairs.  Each array element
+represents a block, but a block contains nothing but entries.  Each pointer has
+type ResInfo\_entry \*, the first is entry\_prev, the second entry\_next.
 
-Before doing anything with EDMAC, you should create a lock for the set of resources / devices you
-wish to use, then later take the lock.  You pass a packed array of {u16 entryIndex, u16 blockNum},
-each a Resource, and a count, to CreateResLockEntry().  This inserts each Resource into the requested
-block (your lock can simultaneously target multiple blocks).  The returned lock can later be
+Canon code has a slightly odd trick, where the prev pointer of the first element
+in the list, and the next pointer of the last element, point to the pointer-pair
+in ResourceInfo\_global.  This isn't a valid ResInfo\_entry, so when walking the
+list you must check the pointer address before accessing ResInfo\_entry fields.
+
+This also means that a block containing no entries will consist of two pointers
+both pointing to the address of the first pointer.
+
+Before doing anything with EDMAC, you should create a lock for the set of
+resources / devices you wish to use, then later take the lock.  You pass a
+packed array of {u16 entryIndex, u16 blockNum}, each a Resource, and a count, to
+CreateResLockEntry().  This inserts each Resource into the requested block (your
+lock can simultaneously target multiple blocks).  The returned lock can later be
 used to either obtain all resources, or non-fatally fail.
 
-ML code doesn't have a struct for Resources, it hard-codes them into a uint32\_t, e.g.:
+ML code doesn't have a struct for Resources,
+it hard-codes them into a uint32\_t, e.g.:
 
     resource = 0x00010000 + i; /* read edmac channel */
 
 That's a reference to block 1 (EDmac reads), entry i.
 
-
-read\_edmacs[] and write\_edmacs[] in edmac.c are found by dumping the contents of blocks 0 and 1.
-Are they?  Docs + forum doesn't really specify.  I think this might be blocks 0 + 2, and 1 + 3.
-
-<div style="page-break-after: always; visibility: hidden"></div>
+read\_edmacs[] and write\_edmacs[] in edmac.c are found by dumping the contents
+of blocks 0 and 1. Are they?  Docs + forum doesn't really specify. I think this
+might be blocks 0 + 2, and 1 + 3.


### PR DESCRIPTION
Markdown is a great format because it allows us to write plain-text with
embedded formatting, and still also be able to wrap to the 80-column terminal
standard.

I made these changes because I find it more readable when you are not using
a markdown editor. This happens often enough for myself.

I made the choice to not wrap markdown links (`()[]`), as it does not affect
readability.

Changes:
- wrap to 80col
- lowercase and add missing periods to stuff like "e.g.", "etc."
- correct casing of "GitHub" (previously "Github")
- add "\*nix" to the message saying that BSDs may work.

  I also want to say that I did test building on OpenBSD (due to it being my OS
  of choice on my laptop) and it appears to work pretty well.
- remove the `<div style="page-break-after: always; visibility: hidden"></div>`
  that seems to be in some markdown files, not sure what it is for?

Reading the documentation in the GitHub web viewer, other than the spelling
corrections, you should notice no difference than the original files.

The point — now both representations are nice to look at.

These changes are opinionated, feel free to close if you disagree with them.
I suggest to squash merge (commit messages are blank here).

Signed-off-by: Mahied Maruf <contact@mechite.com>