### PR TITLE
750D: add PTP handler registration stub

### DIFF
--- a/platform/750D.110/stubs.S
+++ b/platform/750D.110/stubs.S
@@ -180,6 +180,9 @@ THUMB_FN(0xfe445136,  prop_register_slave)                  // Assert "pRegister
 THUMB_FN(0xfe445206, _prop_request_change)                  // Assert "pRequestChange"; 2nd (almost identical) is at 0xfe44574a but uses different struct address - matched to struct from prop_register_slave()
 THUMB_FN(0xfe445718, _prop_cleanup)                         // DebugMsg "ChangeCBR(...". Last call in those functions.
 
+/** PTP **/
+THUMB_FN(0xfe4196f2,  ptp_register_handler)                 // AddListOperationFunction wrapper; candidate for CONFIG_PTP
+
 /** CFn **/
 THUMB_FN(0xFE3600D0, GetCFnData)                            // "GetCFnData"
 THUMB_FN(0xFE36016E, SetCFnData)                            // "SetCFnData"


### PR DESCRIPTION
Add THUMB_FN(0xfe4196f2, ptp_register_handler) to platform/750D.110/stubs.S. This identifies the Canon firmware function used to add operation handlers to the camera PTP operation list.

The added stub lets the existing Magic Lantern PTP code call ptp_register_handler() from the normal ptp_register_all_handlers(). With CONFIG_PTP and CONFIG_PTP_CHDK enabled, the existing CHDK handler for opcode 0x9999 is registered through Canon's native PTP operation list mechanism.

This commit intentionally changes only the 750D.110 platform stub table. It does not modify generic PTP code, the build system, modules, loader behavior, Lua, or any shared source path.

Static diagnosis: the function at 0xfe4196f2 reads Canon's PTP operation-list global, returns 0x17 if the list is not initialized, returns 0x03 for a null handler, and inserts operation nodes through the same list structure used by Canon handlers. After boot, the Canon list global is valid and the operation list contains the newly registered 0x9999 node.

Build testing: make13 CONFIG_PTP=y CONFIG_PTP_CHDK=y build/cam_complete completed successfully on 750D.110 with Arm GNU Toolchain 13.3.Rel1. The resulting image exports ptp_register_all_handlers, ptp_init, __ptp_handler_0x9999, _ptp_handlers_start/_end, and resolves ptp_register_handler to fe4196f3.

Runtime testing on a real EOS 750D / firmware 1.1.0 confirmed that Magic Lantern boots and remains responsive, normal INIT_FUNC-based PTP registration works, CHDK opcode 0x9999 responds, PTP info/version succeeds, GetMemory succeeds, the Canon operation list contains a 0x9999 node, and PTP file upload/download roundtrip in ML/LOGS matches byte-for-byte.

Risk is limited to CONFIG_PTP builds for the 750D.110 platform. Baseline non-PTP behavior is unchanged. If the address were wrong, the expected failure mode would be limited to PTP registration on this platform rather than affecting global ML code.