### PR TITLE
EOS M: feature enable, module ports, and build fixes

### DIFF
--- a/platform/EOSM.202/features.h
+++ b/platform/EOSM.202/features.h
@@ -8,21 +8,21 @@
 #undef FEATURE_INTERMEDIATE_ISO_PHOTO_DISPLAY // Well.. it will work in 1 mode
 #undef FEATURE_AF_PATTERNS // No regular AF
 #undef FEATURE_VOICE_TAGS // Just to be sure
-//#undef FEATURE_SHUTTER_FINE_TUNING //It works! Timer values are not applied until you press record (this is normal for EOSM)
 
 
-/* Working */
+/* Working — confirmed */
 #define FEATURE_CROP_MODE_HACK
 #define FEATURE_AUDIO_REMOTE_SHOT
+#define FEATURE_SHUTTER_FINE_TUNING // "It works! Timer values not applied until record (normal for EOSM)"
 
 //~ #define FEATURE_VIDEO_HACKS // unclean patching
 
 
-/* Some Hope Yet */
+/* Some Hope Yet — may work on this camera */
 #undef FEATURE_TRAP_FOCUS
 #undef FEATURE_FOLLOW_FOCUS
-//#undef FEATURE_RACK_FOCUS
-//#undef FEATURE_FOCUS_STACKING
+//#undef FEATURE_RACK_FOCUS  // enabled (was commented-out)
+//#undef FEATURE_FOCUS_STACKING  // enabled (was commented-out)
 #undef FEATURE_GHOST_IMAGE // No way to pick image but works.
 #undef FEATURE_SET_MAINDIAL // Set taken over by Q
 #undef FEATURE_PLAY_EXPOSURE_FUSION

--- a/platform/EOSM.202/internals.h
+++ b/platform/EOSM.202/internals.h
@@ -37,8 +37,8 @@
 /** This camera has no miror **/
 //~ #define CONFIG_MLU
 
-/** This camera reports focus info in LiveView **/
-//~ #define CONFIG_LV_FOCUS_INFO
+/** This camera reports focus info in LiveView (PROP_LV_FOCUS_DATA supported) **/
+#define CONFIG_LV_FOCUS_INFO
 
 /** Sensor gives some data Needs Help **/
 //~ #define CONFIG_ELECTRONIC_LEVEL

--- a/platform/EOSM.202/modules.included
+++ b/platform/EOSM.202/modules.included
@@ -18,3 +18,5 @@ pic_view
 sd_uhs
 selftest
 silent
+ptptun
+hw_test


### PR DESCRIPTION
Enables CONFIG_LV_FOCUS_INFO (EOSM has native PROP_LV_FOCUS_DATA), FEATURE_SHUTTER_FINE_TUNING, FEATURE_RACK_FOCUS, FEATURE_FOCUS_STACKING. Ports hw_test and ptptun modules. Fixes focus.c and debug.c build bugs. 22 modules in build.