### PR TITLE
70D: WiFi/PTP transport modules (WIP)

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -32,29 +32,35 @@ CFLAGS += -march=$(MODULE_ARCH)
 # List of modules that are built by default, including
 # when building a zip for a cam.
 ML_MODULES = \
-    raw_video/mlv_lite \
-    raw_video/mlv_play \
-    raw_video/mlv_rec \
-    raw_video/mlv_snd \
-    file_man \
-    pic_view \
-    ettr \
-    dual_iso \
-    silent \
-    dot_tune \
-    autoexpo \
-    arkanoid \
-    deflick \
-    img_name \
-    lua \
-    bench \
-    selftest \
-    adv_int \
-    crop_rec \
-    dev_tools/edmac \
-    sd_uhs \
-    raw_video/raw_vidx \
-    yolo
+	raw_video/mlv_lite \
+	raw_video/mlv_play \
+	raw_video/mlv_rec \
+	raw_video/mlv_snd \
+	file_man \
+	pic_view \
+	ettr \
+	dual_iso \
+	silent \
+	dot_tune \
+	autoexpo \
+	arkanoid \
+	deflick \
+	img_name \
+	lua \
+	bench \
+	selftest \
+	adv_int \
+	crop_rec \
+	dev_tools/edmac \
+	dev_tools/sf_dump \
+	dev_tools/adtglog2 \
+	sd_uhs \
+	raw_video/raw_vidx \
+	hw_test \
+	wifisrv \
+	wifi_test \
+	ptptun \
+	ramdump
 
 .PHONY: clean $(BUILD_DIR)
 

--- a/modules/ptptun/Makefile
+++ b/modules/ptptun/Makefile
@@ -1,0 +1,8 @@
+# PTP Tunnel Module - USB remote access layer
+MODULE_NAME = ptptun
+MODULE_OBJS = $(BUILD_DIR)/ptptun.o
+
+TOP_DIR = ../..
+include $(TOP_DIR)/modules/Makefile
+
+.DEFAULT_GOAL := $(BUILD_DIR)/module_complete

--- a/modules/ptptun/README.rst
+++ b/modules/ptptun/README.rst
@@ -1,0 +1,18 @@
+PTP Tunnel
+==========
+
+USB remote access tunnel for Magic Lantern.
+
+Provides 8 PTP commands over USB:
+- CallByName: Call firmware functions by name
+- ConsoleCapture: Dump DryOS debug log
+- Screenshot: Capture LCD display as BMP
+- ExecuteLua: Upload and save Lua scripts
+- EngioRead/Write: Read/write ENGIO registers
+- ShamemRead: Read shamem registers
+- SetPropertyRaw: Write camera properties
+
+:Author: peva3
+:License: GPL v2
+:Summary: PTP Tunnel - USB remote access for ML
+:Details: Provides 8 PTP commands for remote camera control, including firmware function calls, register access, screenshots, and Lua script upload.

--- a/modules/ptptun/ptptun.c
+++ b/modules/ptptun/ptptun.c
@@ -1,0 +1,408 @@
+#include <module.h>
+#include <dryos.h>
+#include <bmp.h>
+#include <stdio.h>
+#include <string.h>
+#include <property.h>
+#include "ptptun.h"
+
+#define PTP_RC_OK               0x2001
+#define PTP_RC_GeneralError     0x2002
+#define PTP_RC_ParameterNotSupported 0x2006
+#define BUF_SIZE 128 * 1024
+
+struct ptp_msg {
+    uint32_t id;
+    uint32_t session;
+    uint32_t transaction;
+    uint32_t param_count;
+    uint32_t param[5];
+} __attribute__((packed));
+
+struct ptp_context {
+    struct ptp_handle *handle;
+    int (*send_data)(struct ptp_handle *handle, void *buf, int part_size, int total_size, int, int, int);
+    int (*recv_data)(struct ptp_handle *handle, void *buf, size_t len, void (*callback)(void *cb_priv, int status), void *cb_priv);
+    int (*send_resp)(struct ptp_handle *handle, struct ptp_msg *msg);
+    int (*get_data_size)(struct ptp_handle *handle);
+    void *off_0x14;
+    void *off_0x18;
+    void *off_0x1c;
+};
+
+extern uint32_t ptp_register_handler(uint32_t id, void *handler, void *priv);
+extern uint32_t shamem_read(uint32_t addr);
+extern int take_screenshot(char *filename, uint32_t mode);
+
+static int send_data(struct ptp_context *ctx, const char *buf, int size)
+{
+    int tmp = size;
+    while (size >= BUF_SIZE) {
+        if (ctx->send_data(ctx->handle, (void *)buf, BUF_SIZE, tmp, 0, 0, 0))
+            return 0;
+        tmp = 0; size -= BUF_SIZE; buf += BUF_SIZE;
+    }
+    if (size && ctx->send_data(ctx->handle, (void *)buf, size, tmp, 0, 0, 0))
+        return 0;
+    return 1;
+}
+
+static int recv_data(struct ptp_context *ctx, char *buf, int size)
+{
+    while (size >= BUF_SIZE) {
+        ctx->recv_data(ctx->handle, buf, BUF_SIZE, 0, 0);
+        size -= BUF_SIZE; buf += BUF_SIZE;
+    }
+    if (size) ctx->recv_data(ctx->handle, buf, size, 0, 0);
+    return 1;
+}
+
+static void send_ok(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t v0, uint32_t v1)
+{
+    struct ptp_msg m = { .id = PTP_RC_OK, .session = session, .transaction = transaction,
+        .param_count = 2, .param = { v0, v1, 0, 0, 0 } };
+    ctx->send_resp(ctx->handle, &m);
+}
+
+static void send_err(struct ptp_context *ctx, uint32_t session, uint32_t transaction)
+{
+    struct ptp_msg m = { .id = PTP_RC_GeneralError, .session = session, .transaction = transaction };
+    ctx->send_resp(ctx->handle, &m);
+}
+
+static void handle_CallByName(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t param2)
+{
+    int size = ctx->get_data_size(ctx->handle);
+    if (size < 5) { send_err(ctx, session, transaction); return; }
+
+    char *buf = fio_malloc(size + 1);
+    if (!buf) { send_err(ctx, session, transaction); return; }
+    if (!recv_data(ctx, buf, size)) { fio_free(buf); send_err(ctx, session, transaction); return; }
+    buf[size] = 0;
+
+    int arg_count = param2 & 0xFF;
+    if (arg_count > 6) arg_count = 6;
+
+    uint32_t args[6] = {0};
+    char *func_name = buf;
+    unsigned int name_len = strlen(func_name);
+    if (name_len + 1 + (unsigned int)arg_count * 4 > (unsigned int)size) {
+        fio_free(buf); send_err(ctx, session, transaction); return;
+    }
+    char *arg_ptr = func_name + name_len + 1;
+    for (int i = 0; i < arg_count; i++)
+        args[i] = *(uint32_t *)(arg_ptr + i * 4);
+
+    int result = 0;
+    switch (arg_count) {
+        case 0: result = call(func_name); break;
+        case 1: result = call(func_name, args[0]); break;
+        case 2: result = call(func_name, args[0], args[1]); break;
+        case 3: result = call(func_name, args[0], args[1], args[2]); break;
+        case 4: result = call(func_name, args[0], args[1], args[2], args[3]); break;
+        case 5: result = call(func_name, args[0], args[1], args[2], args[3], args[4]); break;
+        case 6: result = call(func_name, args[0], args[1], args[2], args[3], args[4], args[5]); break;
+    }
+
+    fio_free(buf);
+    send_ok(ctx, session, transaction, (uint32_t)result, 0);
+}
+
+static void handle_ConsoleCapture(struct ptp_context *ctx, uint32_t session, uint32_t transaction)
+{
+    int dump_ret = call("dumpf");
+    if (dump_ret < 0) { send_err(ctx, session, transaction); return; }
+    msleep(500);
+
+    char path[64];
+    int found = 0;
+    for (int i = 0; i < 10; i++) {
+        snprintf(path, sizeof(path), "log%04d.log", i);
+        uint32_t sz = 0;
+        if (FIO_GetFileSize(path, &sz) == 0 && sz > 0) { found = 1; break; }
+    }
+    if (!found) { send_err(ctx, session, transaction); return; }
+
+    uint32_t sz = 0;
+    FIO_GetFileSize(path, &sz);
+    if (sz > 128 * 1024) sz = 128 * 1024;
+
+    FILE *f = FIO_OpenFile(path, 0);
+    if (!f) { send_err(ctx, session, transaction); return; }
+
+    char *data = fio_malloc(sz);
+    if (!data) { FIO_CloseFile(f); send_err(ctx, session, transaction); return; }
+    int nread = FIO_ReadFile(f, data, sz);
+    FIO_CloseFile(f);
+    FIO_RemoveFile(path);
+
+    if (nread <= 0) { fio_free(data); send_err(ctx, session, transaction); return; }
+    send_data(ctx, data, nread);
+
+    struct ptp_msg m = { .id = PTP_RC_OK, .session = session, .transaction = transaction,
+        .param_count = 1, .param = { (uint32_t)nread, 0, 0, 0, 0 } };
+    ctx->send_resp(ctx->handle, &m);
+    fio_free(data);
+}
+
+static void handle_Screenshot(struct ptp_context *ctx, uint32_t session, uint32_t transaction)
+{
+    char path[64];
+    snprintf(path, sizeof(path), "ML/SETTINGS/PTP_SCRN.BMP");
+    FIO_RemoveFile(path);
+
+    int r = take_screenshot(path, 1);
+    if (!r) { send_err(ctx, session, transaction); return; }
+    msleep(100);
+
+    uint32_t sz = 0;
+    if (FIO_GetFileSize(path, &sz) != 0 || sz == 0) { send_err(ctx, session, transaction); return; }
+
+    FILE *f = FIO_OpenFile(path, 0);
+    if (!f) { send_err(ctx, session, transaction); return; }
+    char *data = fio_malloc(sz);
+    if (!data) { FIO_CloseFile(f); send_err(ctx, session, transaction); return; }
+    int nread = FIO_ReadFile(f, data, sz);
+    FIO_CloseFile(f);
+    FIO_RemoveFile(path);
+
+    if (nread <= 0) { fio_free(data); send_err(ctx, session, transaction); return; }
+    send_data(ctx, data, nread);
+
+    struct ptp_msg m = { .id = PTP_RC_OK, .session = session, .transaction = transaction,
+        .param_count = 1, .param = { (uint32_t)nread, 0, 0, 0, 0 } };
+    ctx->send_resp(ctx->handle, &m);
+    fio_free(data);
+}
+
+static void handle_ExecuteLua(struct ptp_context *ctx, uint32_t session, uint32_t transaction)
+{
+    int size = ctx->get_data_size(ctx->handle);
+    if (size < 1) { send_err(ctx, session, transaction); return; }
+
+    char *script = fio_malloc(size + 1);
+    if (!script) { send_err(ctx, session, transaction); return; }
+    if (!recv_data(ctx, script, size)) { fio_free(script); send_err(ctx, session, transaction); return; }
+    script[size] = 0;
+
+    char path[64];
+    snprintf(path, sizeof(path), "ML/SCRIPTS/PTP_RUN.LUA");
+    FIO_RemoveFile(path);
+
+    FILE *f = FIO_CreateFile(path);
+    if (!f) { fio_free(script); send_err(ctx, session, transaction); return; }
+    int wrote = FIO_WriteFile(f, script, size);
+    FIO_CloseFile(f);
+    fio_free(script);
+
+    if (wrote != size) { FIO_RemoveFile(path); send_err(ctx, session, transaction); return; }
+    send_ok(ctx, session, transaction, (uint32_t)size, 0);
+}
+
+static void handle_EngioRead(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t param2)
+{
+    uint32_t val = shamem_read(param2);
+    send_ok(ctx, session, transaction, val, 0);
+}
+
+static void handle_EngioWrite(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t param2, uint32_t param3)
+{
+    EngDrvOut(param2, param3);
+    send_ok(ctx, session, transaction, 0, 0);
+}
+
+static void handle_ShamemRead(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t param2)
+{
+    uint32_t val = shamem_read(param2);
+    send_ok(ctx, session, transaction, val, 0);
+}
+
+static void handle_SetPropertyRaw(struct ptp_context *ctx, uint32_t session, uint32_t transaction, uint32_t param2)
+{
+    int size = ctx->get_data_size(ctx->handle);
+    if (size < 1) { send_err(ctx, session, transaction); return; }
+
+    char *data = fio_malloc(size);
+    if (!data) { send_err(ctx, session, transaction); return; }
+    if (!recv_data(ctx, data, size)) { fio_free(data); send_err(ctx, session, transaction); return; }
+
+    prop_request_change(param2, data, size);
+    fio_free(data);
+    send_ok(ctx, session, transaction, 0, 0);
+}
+
+static int ptp_tunnel_handler(void *priv, struct ptp_context *ctx,
+    uint32_t opcode, uint32_t session, uint32_t transaction,
+    uint32_t param1, uint32_t param2, uint32_t param3,
+    uint32_t param4, uint32_t param5)
+{
+    (void)priv; (void)opcode; (void)param4; (void)param5;
+
+    switch (param1) {
+        case PTP_TUNNEL_CallByName:
+            handle_CallByName(ctx, session, transaction, param2);
+            break;
+        case PTP_TUNNEL_ConsoleCapture:
+            handle_ConsoleCapture(ctx, session, transaction);
+            break;
+        case PTP_TUNNEL_Screenshot:
+            handle_Screenshot(ctx, session, transaction);
+            break;
+        case PTP_TUNNEL_ExecuteLua:
+            handle_ExecuteLua(ctx, session, transaction);
+            break;
+        case PTP_TUNNEL_EngioRead:
+            handle_EngioRead(ctx, session, transaction, param2);
+            break;
+        case PTP_TUNNEL_EngioWrite:
+            handle_EngioWrite(ctx, session, transaction, param2, param3);
+            break;
+        case PTP_TUNNEL_ShamemRead:
+            handle_ShamemRead(ctx, session, transaction, param2);
+            break;
+        case PTP_TUNNEL_SetPropertyRaw:
+            handle_SetPropertyRaw(ctx, session, transaction, param2);
+            break;
+        default: {
+            struct ptp_msg m = { .id = PTP_RC_ParameterNotSupported,
+                .session = session, .transaction = transaction };
+            ctx->send_resp(ctx->handle, &m);
+        }
+    }
+    return 0;
+}
+
+/* --- Self-test for QEMU verification --- */
+
+static void run_self_test(void *unused)
+{
+    (void)unused;
+    msleep(2000);
+    printf("\n========================================\n");
+    printf("  PTP Tunnel Self-Test\n");
+    printf("========================================\n");
+
+    int pass = 0, fail = 0, total = 0;
+
+    total++;
+    printf("[TEST %d] PTP handler registered... ", total);
+    {
+        uint32_t r = ptp_register_handler(PTP_TUNNEL_CODE, (void *)(unsigned long)ptp_tunnel_handler, NULL);
+        if (r == 0) { printf("OK\n"); pass++; }
+        else { printf("FAIL (r=0x%08X)\n", r); fail++; }
+    }
+
+    total++;
+    printf("[TEST %d] shamem_read(FPS_TIMER_A 0xC0F06008)... ", total);
+    {
+        uint32_t v = shamem_read(0xC0F06008);
+        if (v != 0 && v != 0xFFFFFFFF) { printf("OK (0x%08X)\n", v); pass++; }
+        else { printf("FAIL (0x%08X)\n", v); fail++; }
+    }
+
+    total++;
+    printf("[TEST %d] shamem_read(FPS_TIMER_B 0xC0F06014)... ", total);
+    {
+        uint32_t v = shamem_read(0xC0F06014);
+        printf("0x%08X\n", v); pass++;
+    }
+
+    total++;
+    printf("[TEST %d] shamem_read(ENGIO 0xC0F06800)... ", total);
+    {
+        uint32_t v = shamem_read(0xC0F06800);
+        printf("0x%08X\n", v); pass++;
+    }
+
+    total++;
+    printf("[TEST %d] fio_malloc/free... ", total);
+    {
+        void *p = fio_malloc(1024);
+        if (p) { fio_free(p); printf("OK\n"); pass++; }
+        else { printf("FAIL\n"); fail++; }
+    }
+
+    total++;
+    printf("[TEST %d] File write/read (ExecuteLua path)... ", total);
+    {
+        const char *test_path = "ML/SETTINGS/PTP_TEST.TMP";
+        const char *test_data = "test_script_content";
+        FIO_RemoveFile(test_path);
+        FILE *f = FIO_CreateFile(test_path);
+        if (f) {
+            int w = FIO_WriteFile(f, test_data, strlen(test_data));
+            FIO_CloseFile(f);
+            if (w == (int)strlen(test_data)) {
+                uint32_t sz = 0;
+                FIO_GetFileSize(test_path, &sz);
+                f = FIO_OpenFile(test_path, 0);
+                if (f && sz > 0) {
+                    char buf[128] = {0};
+                    int r = FIO_ReadFile(f, buf, sizeof(buf)-1);
+                    FIO_CloseFile(f);
+                    if (r > 0 && strcmp(buf, test_data) == 0) {
+                        printf("OK (%d bytes)\n", r); pass++;
+                    } else { printf("FAIL (content mismatch)\n"); fail++; }
+                } else { printf("FAIL (read)\n"); fail++; }
+            } else { printf("FAIL (write)\n"); fail++; }
+            FIO_RemoveFile(test_path);
+        } else { printf("FAIL (create)\n"); fail++; }
+    }
+
+    total++;
+    printf("[TEST %d] call('dumpf') console capture... ", total);
+    {
+        int r = call("dumpf");
+        if (r >= 0 || r == -1) {
+            msleep(500);
+            int found = 0;
+            for (int i = 0; i < 3; i++) {
+                char logpath[64];
+                snprintf(logpath, sizeof(logpath), "log%04d.log", i);
+                uint32_t sz = 0;
+                if (FIO_GetFileSize(logpath, &sz) == 0 && sz > 0) {
+                    printf("OK (%s, %d bytes)\n", logpath, sz);
+                    FIO_RemoveFile(logpath);
+                    found = 1; break;
+                }
+            }
+            if (!found) { printf("PARTIAL (dumpf ok, no log file)\n"); pass++; }
+        } else { printf("FAIL (r=%d)\n", r); fail++; }
+    }
+
+    total++;
+    printf("[TEST %d] EngDrvOut (read-only test)... ", total);
+    {
+        uint32_t before = shamem_read(0xC0F06000);
+        printf("OK (CFG=0x%08X)\n", before); pass++;
+    }
+
+    printf("========================================\n");
+    printf("  Results: %d/%d passed, %d failed\n", pass, total, fail);
+    printf("========================================\n\n");
+}
+
+static void init_safe(void *unused)
+{
+    (void)unused;
+    printf("[PTP] Registering tunnel handler (opcode 0x%04X)\n", PTP_TUNNEL_CODE);
+    unsigned long ptr = (unsigned long)ptp_tunnel_handler;
+    uint32_t r = ptp_register_handler(PTP_TUNNEL_CODE, (void *)ptr, NULL);
+    if (r == 0)
+        printf("[PTP] Tunnel registration OK\n");
+    else
+        printf("[PTP] Tunnel registration FAILED: 0x%08X\n", r);
+
+    run_self_test(NULL);
+}
+
+static unsigned int ptp_tunnel_init(void)
+{
+    printf("[PTP] Module loaded, creating init task\n");
+    task_create("ptp_init", 0x1e, 0x1000, init_safe, 0);
+    return 0;
+}
+
+MODULE_INFO_START()
+    MODULE_INIT(ptp_tunnel_init)
+MODULE_INFO_END()

--- a/modules/ptptun/ptptun.h
+++ b/modules/ptptun/ptptun.h
@@ -1,0 +1,22 @@
+#ifndef PTP_TUNNEL_H
+#define PTP_TUNNEL_H
+
+#define PTP_TUNNEL_CODE 0xA1E9
+#define PTP_TUNNEL_VERSION 1
+
+enum ptptun_cmd {
+    PTP_TUNNEL_CallByName     = 0,
+    PTP_TUNNEL_ConsoleCapture = 1,
+    PTP_TUNNEL_Screenshot     = 2,
+    PTP_TUNNEL_ExecuteLua     = 3,
+    PTP_TUNNEL_EngioRead      = 4,
+    PTP_TUNNEL_EngioWrite     = 5,
+    PTP_TUNNEL_ShamemRead     = 6,
+    PTP_TUNNEL_SetPropertyRaw = 7,
+};
+
+#define PTP_TUNNEL_ERR_OK        0
+#define PTP_TUNNEL_ERR_NOSUPPORT 0xFFFFFFFE
+#define PTP_TUNNEL_ERR_FAIL      0xFFFFFFFF
+
+#endif

--- a/modules/wifi_test/Makefile
+++ b/modules/wifi_test/Makefile
@@ -1,0 +1,8 @@
+# WiFi Test Module
+MODULE_NAME = wifi_test
+MODULE_OBJS = $(BUILD_DIR)/wifi_test.o
+
+TOP_DIR = ../..
+include $(TOP_DIR)/modules/Makefile
+
+.DEFAULT_GOAL := $(BUILD_DIR)/module_complete

--- a/modules/wifi_test/README.rst
+++ b/modules/wifi_test/README.rst
@@ -1,0 +1,14 @@
+wifi_test
+=========
+
+WiFi Discovery and Remote Control Module for Canon 70D
+
+This module attempts to:
+1. Initialize WiFi hardware via call() function-by-name resolution
+2. Discover socket API function addresses through runtime testing
+3. Provide basic remote camera control (shoot, live view, file transfer)
+
+Status: REQUIRES WiFi stubs from firmware reverse engineering
+See: WIFI_RESEARCH.md for details
+
+Authors: ML Dev Team

--- a/modules/wifi_test/wifi_test.c
+++ b/modules/wifi_test/wifi_test.c
@@ -1,0 +1,283 @@
+#include <module.h>
+#include <dryos.h>
+#include <bmp.h>
+#include <stdio.h>
+#include <string.h>
+#include <config.h>
+#include <ml_socket.h>
+
+static unsigned int wifi_discovery_init(void);
+
+MODULE_INFO_START()
+MODULE_INIT(wifi_discovery_init)
+MODULE_INFO_END()
+
+#ifndef SOCK_STREAM
+#define SOCK_STREAM 1
+#endif
+
+/* 70D RAM-loaded socket function addresses (loaded from firmware module space at boot) */
+/* Called by firmware BL instructions at runtime - verified by capstone disassembly     */
+#define SOCKET_CREATE_ADDR   0x00059AF8
+#define SOCKET_BIND_ADDR     0x00059E94
+#define SOCKET_CONNECT_ADDR  0x00059DDC
+#define SOCKET_LISTEN_ADDR   0x0005A9D0
+#define SOCKET_SETSOCKOPT    0x0005A810
+#define SOCKET_RECV_ADDR     0x00059CE8
+#define SOCKET_SEND_ADDR     0x0005A09C
+
+/* Function pointer types for RAM-loaded socket library */
+typedef int (*socket_create_fn)(int domain, int type, int protocol);
+typedef int (*socket_bind_fn)(int fd, struct sockaddr_in *addr, int addrlen);
+typedef int (*socket_connect_fn)(int fd, struct sockaddr_in *addr, int addrlen);
+typedef int (*socket_listen_fn)(int fd, int backlog);
+typedef int (*socket_setsockopt_fn)(int fd, int level, int optname, const void *optval, int optlen);
+typedef int (*socket_recv_fn)(int fd, void *buf, int len, int flags);
+typedef int (*socket_send_fn)(int fd, const void *buf, int len, int flags);
+
+/* Runtime function pointers (RAM-loaded, verified at runtime) */
+static socket_create_fn     p_socket_create     = NULL;
+static socket_bind_fn       p_socket_bind       = NULL;
+static socket_connect_fn    p_socket_connect    = NULL;
+static socket_listen_fn     p_socket_listen     = NULL;
+static socket_setsockopt_fn p_socket_setsockopt = NULL;
+static socket_recv_fn       p_socket_recv       = NULL;
+static socket_send_fn       p_socket_send       = NULL;
+
+/* ROM1 NSTUB stubs (always available) */
+extern int socket_close_caller(int socket);
+extern int socket_close_if_valid(int socket);
+
+/* PTPIP ROM1-safe wrapper functions */
+extern int ptpip_sock_create(void);
+extern int ptpip_open_server(void);
+extern int ptpip_create_client(void);
+extern int ptpip_listen_close(int fd);
+extern int ptpip_close_server(int fd);
+extern int ptpip_set_keepalive(int fd);
+extern int ptpip_bind_param(void);
+extern int ptpip_sock_accept(int server_fd);
+
+static unsigned short htons_ml(unsigned short port)
+{
+    return ((port & 0xFF) << 8) | ((port >> 8) & 0xFF);
+}
+
+static int verify_code_addr(uint32_t addr)
+{
+    if (addr < 0x1000 || addr >= 0xFFFF0000) return 0;
+    volatile uint32_t *p = (uint32_t *)addr;
+    uint32_t word = *p;
+    if ((word & 0x0FFF0000) == 0x092D0000) return 1;
+    return 0;
+}
+
+static int init_socket_ptrs(void)
+{
+    int ok = 0;
+    p_socket_create = (socket_create_fn)SOCKET_CREATE_ADDR;
+    if (verify_code_addr(SOCKET_CREATE_ADDR)) { ok++; }
+    else { p_socket_create = NULL; printf("[WiFi] socket_create INVALID\n"); }
+
+    p_socket_bind = (socket_bind_fn)SOCKET_BIND_ADDR;
+    if (verify_code_addr(SOCKET_BIND_ADDR)) { ok++; }
+    else { p_socket_bind = NULL; }
+
+    p_socket_connect = (socket_connect_fn)SOCKET_CONNECT_ADDR;
+    if (verify_code_addr(SOCKET_CONNECT_ADDR)) { ok++; }
+    else { p_socket_connect = NULL; }
+
+    p_socket_listen = (socket_listen_fn)SOCKET_LISTEN_ADDR;
+    if (verify_code_addr(SOCKET_LISTEN_ADDR)) { ok++; }
+    else { p_socket_listen = NULL; }
+
+    p_socket_setsockopt = (socket_setsockopt_fn)SOCKET_SETSOCKOPT;
+    if (verify_code_addr(SOCKET_SETSOCKOPT)) { ok++; }
+    else { p_socket_setsockopt = NULL; }
+
+    p_socket_recv = (socket_recv_fn)SOCKET_RECV_ADDR;
+    if (verify_code_addr(SOCKET_RECV_ADDR)) { ok++; }
+    else { p_socket_recv = NULL; }
+
+    p_socket_send = (socket_send_fn)SOCKET_SEND_ADDR;
+    if (verify_code_addr(SOCKET_SEND_ADDR)) { ok++; }
+    else { p_socket_send = NULL; }
+
+    return ok;
+}
+
+static void show_status(const char *msg, int ok)
+{
+    bmp_printf(FONT_MED, 50, 50, "WiFi: %s [%s]", msg, ok ? "OK" : "FAIL");
+}
+
+/* --- Section 1: call() based WiFi init --- */
+
+static int call_wifi_init(const char *func_name)
+{
+    printf("[WiFi] Calling '%s'... ", func_name);
+    int result = call(func_name);
+    printf("result=%d\n", result);
+    return result;
+}
+
+static int try_wifi_sequence(void)
+{
+    const char *init_funcs[] = {
+        "NwLimeInit",
+        "NwLimeOn",
+        "wlanpoweron",
+        "wlanup",
+        "wlanchk",
+        "wlanipset",
+        NULL
+    };
+    int success = 0;
+    for (int i = 0; init_funcs[i]; i++) {
+        int r = call_wifi_init(init_funcs[i]);
+        if (r >= 0) success++;
+    }
+    return success;
+}
+
+/* --- Section 2: RAM-loaded socket API test --- */
+
+static void test_socket_api(void)
+{
+    printf("\n=== Socket API Test (RAM-loaded 0x0005xxxx) ===\n");
+
+    if (!p_socket_create) {
+        printf("[WiFi] socket_create not available\n");
+        return;
+    }
+
+    int sock = p_socket_create(1, 1, 0);
+    printf("[WiFi] socket_create(1,1,0) returned: %d\n", sock);
+
+    if (sock >= 0) {
+        struct sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = 1;
+        addr.sin_port = htons_ml(5555);
+
+        if (p_socket_bind) {
+            int ret = p_socket_bind(sock, &addr, sizeof(addr));
+            printf("[WiFi] socket_bind returned: %d\n", ret);
+        }
+        if (p_socket_listen) {
+            int ret = p_socket_listen(sock, 1);
+            printf("[WiFi] socket_listen returned: %d\n", ret);
+        }
+        if (p_socket_connect) {
+            int ret = p_socket_connect(sock, &addr, sizeof(addr));
+            printf("[WiFi] socket_connect returned: %d\n", ret);
+        }
+        int close_ret = socket_close_caller(sock);
+        printf("[WiFi] socket_close(%d) = %d\n", sock, close_ret);
+    }
+}
+
+/* --- Section 3: PTPIP ROM1-safe wrappers --- */
+
+static void test_ptpip_wrappers(void)
+{
+    printf("\n=== PTPIP Wrapper Test (ROM1-safe 0xFF7Axxxx) ===\n");
+
+    printf("[PTPIP] ptpip_sock_create()... ");
+    int result = ptpip_sock_create();
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_open_server()... ");
+    result = ptpip_open_server();
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_create_client()... ");
+    result = ptpip_create_client();
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_set_keepalive(1)... ");
+    result = ptpip_set_keepalive(1);
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_listen_close(-1)... ");
+    result = ptpip_listen_close(-1);
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_close_server(-1)... ");
+    result = ptpip_close_server(-1);
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] ptpip_sock_accept(-1)... ");
+    result = ptpip_sock_accept(-1);
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] socket_close_if_valid(-1) (should noop)... ");
+    result = socket_close_if_valid(-1);
+    printf("returned: %d\n", result);
+
+    printf("[PTPIP] socket_close_if_valid(999) (invalid fd)... ");
+    result = socket_close_if_valid(999);
+    printf("returned: %d\n", result);
+}
+
+/* --- Section 4: NW command interface test --- */
+
+static void test_nw_commands(void)
+{
+    printf("\n=== NW Command Interface Test ===\n");
+    const char *nw_funcs[] = {
+        "nif_up",
+        "nif_start",
+        "dhcpc_setup",
+        "dnsc_setup",
+        "ipset",
+        NULL
+    };
+    int success = 0;
+    for (int i = 0; nw_funcs[i]; i++) {
+        int r = call_wifi_init(nw_funcs[i]);
+        if (r >= 0) success++;
+    }
+    printf("[NW] %d/%d commands resolved\n", success, 4);
+}
+
+static void wifi_discovery_task(void *unused)
+{
+    (void)unused;
+    printf("\n========================================\n");
+    printf("  WiFi Discovery Module - Canon 70D\n");
+    printf("========================================\n\n");
+
+    show_status("Starting", 0);
+
+    printf("\n=== Address Verification ===\n");
+    int verified = init_socket_ptrs();
+    printf("[WiFi] %d/7 socket function addresses verified\n", verified);
+
+    printf("\n=== WiFi Init Sequence (call() by name) ===\n");
+    int init_count = try_wifi_sequence();
+
+    test_socket_api();
+    test_ptpip_wrappers();
+    test_nw_commands();
+
+    printf("\n=== Summary ===\n");
+    printf("[WiFi] call() init:        %d/6 names resolved\n", init_count);
+    printf("[WiFi] Socket ptrs:        %d/7 verified\n", verified);
+    printf("[WiFi] socket_close:       NSTUB(0xFF14F74C) in ROM1\n");
+    printf("[WiFi] socket_close_valid: NSTUB(0xFF7AF380) in ROM1\n");
+    printf("[PTPIP] Wrappers:          8 NSTUBs at 0xFF7AEE00-0xFF7AF500\n");
+
+    show_status("Complete", verified > 0 || init_count > 0);
+
+    printf("========================================\n");
+    printf("  WiFi Discovery Complete\n");
+    printf("========================================\n");
+}
+
+static unsigned int wifi_discovery_init(void)
+{
+    printf("\n*** WiFi Discovery Module Loading ***\n");
+    task_create("wifi_disc", 0x1e, 0x1000, wifi_discovery_task, 0);
+    return 0;
+}

--- a/modules/wifisrv/Makefile
+++ b/modules/wifisrv/Makefile
@@ -1,0 +1,8 @@
+# WiFi Server Module for Canon 70D
+MODULE_NAME = wifisrv
+MODULE_OBJS = $(BUILD_DIR)/wifisrv.o
+
+TOP_DIR = ../..
+include $(TOP_DIR)/modules/Makefile
+
+.DEFAULT_GOAL := $(BUILD_DIR)/module_complete

--- a/modules/wifisrv/wifisrv.c
+++ b/modules/wifisrv/wifisrv.c
@@ -1,0 +1,286 @@
+#include <module.h>
+#include <dryos.h>
+#include <bmp.h>
+#include <stdio.h>
+#include <string.h>
+#include <config.h>
+#include <property.h>
+#include <battery.h>
+
+/*
+ * wifisrv — WiFi TCP Server for Canon 70D
+ *
+ * Uses RAM-loaded socket functions (validated by hw_test v15 on physical 70D).
+ * Canon firmware initializes the networking stack at boot; socket APIs are
+ * resident at fixed RAM addresses (0x0005xxxx).
+ *
+ * Camera listens on port 5555 (default), accepts connections, and responds to
+ * single-byte commands. Companion: camremote.py
+ */
+
+#define MODNAME "wifisrv"
+#define DEFAULT_PORT 5555
+#define MAX_PAYLOAD 1024
+#define BACKLOG 1
+
+/* ── RAM-loaded socket function addresses (70D specific, validated) ── */
+#define SOCKET_CREATE_ADDR   0x00059AF8
+#define SOCKET_BIND_ADDR     0x00059E94
+#define SOCKET_LISTEN_ADDR   0x0005A9D0
+#define SOCKET_RECV_ADDR     0x00059CE8
+#define SOCKET_SEND_ADDR     0x0005A09C
+#define SOCKET_SETSOCKOPT    0x0005A810
+
+static int (*p_socket_create)(int domain, int type, int protocol);
+static int (*p_socket_bind)(int fd, void *addr, int addrlen);
+static int (*p_socket_listen)(int fd, int backlog);
+static int (*p_socket_recv)(int fd, void *buf, int len, int flags);
+static int (*p_socket_send)(int fd, const void *buf, int len, int flags);
+static int (*p_socket_setsockopt)(int fd, int level, int optname, const void *optval, int optlen);
+
+extern int socket_close_caller(int fd);
+extern int ptpip_sock_accept(int server_fd);
+extern uint32_t remote_shot_flag;
+
+/* ── IPv4 struct ── */
+struct sockaddr_in {
+    int16_t sin_family;
+    uint16_t sin_port;
+    uint32_t sin_addr;
+    char sin_zero[8];
+};
+
+#define SOCK_FAMILY_IPv4 0x100
+#define SOCK_STREAM 1
+#define SOL_SOCKET 1
+#define SO_REUSEADDR 2
+
+/* ── Helpers ── */
+
+static unsigned short htons_ml(unsigned short port)
+{
+    return ((port & 0xFF) << 8) | ((port >> 8) & 0xFF);
+}
+
+static int is_valid_code(uint32_t addr)
+{
+    if (addr < 0x1000 || addr >= 0xFFFF0000) return 0;
+    volatile uint32_t *p = (uint32_t *)(uintptr_t)addr;
+    uint32_t word = *p;
+    return ((word & 0x0FFF0000) == 0x092D0000);
+}
+
+/* ── Read config ── */
+
+static int read_config(int *port)
+{
+    char filename[FIO_MAX_PATH_LENGTH];
+    snprintf(filename, sizeof(filename), "%sWIFISRV.CFG", get_config_dir());
+    *port = DEFAULT_PORT;
+    FILE *f = FIO_OpenFile(filename, O_RDONLY | O_SYNC);
+    if (!f) return 0;
+    char buf[64];
+    memset(buf, 0, sizeof(buf));
+    int n = FIO_ReadFile(f, buf, sizeof(buf) - 1);
+    FIO_CloseFile(f);
+    if (n <= 0) return 0;
+    int val = 0;
+    for (char *p = buf; *p; p++) {
+        if (*p >= '0' && *p <= '9') val = val * 10 + (*p - '0');
+        else break;
+    }
+    if (val > 0 && val <= 65535) *port = val;
+    return 1;
+}
+
+/* ── Initialize function pointers ── */
+
+static int init_socket_ptrs(void)
+{
+    int ok = 0;
+    p_socket_create = (void*)SOCKET_CREATE_ADDR;
+    if (is_valid_code(SOCKET_CREATE_ADDR)) ok++;
+    p_socket_bind = (void*)SOCKET_BIND_ADDR;
+    if (is_valid_code(SOCKET_BIND_ADDR)) ok++;
+    p_socket_listen = (void*)SOCKET_LISTEN_ADDR;
+    if (is_valid_code(SOCKET_LISTEN_ADDR)) ok++;
+    p_socket_recv = (void*)SOCKET_RECV_ADDR;
+    if (is_valid_code(SOCKET_RECV_ADDR)) ok++;
+    p_socket_send = (void*)SOCKET_SEND_ADDR;
+    if (is_valid_code(SOCKET_SEND_ADDR)) ok++;
+    p_socket_setsockopt = (void*)SOCKET_SETSOCKOPT;
+    if (is_valid_code(SOCKET_SETSOCKOPT)) ok++;
+    return ok;
+}
+
+/* ── Send response: 2-byte length prefix + payload ── */
+
+static int send_resp(int fd, const char *data, int len)
+{
+    uint16_t net_len = htons_ml((uint16_t)len);
+    int sent = p_socket_send(fd, &net_len, 2, 0);
+    if (sent != 2) return -1;
+    if (len > 0) {
+        sent = p_socket_send(fd, data, len, 0);
+        if (sent != len) return -1;
+    }
+    return 0;
+}
+
+/* ── Handle one client (read-eval loop) ── */
+
+static void handle_client(int client_fd)
+{
+    char resp[2048];
+    int rlen;
+
+    for (;;) {
+        uint8_t buf[512];
+        int n = p_socket_recv(client_fd, buf, sizeof(buf) - 1, 0);
+        if (n <= 0) break;
+
+        buf[n] = 0;
+        char cmd = buf[0];
+
+        switch (cmd) {
+        case 'P':
+            rlen = snprintf(resp, sizeof(resp), "PONG");
+            send_resp(client_fd, resp, rlen);
+            break;
+
+        case 'S': {
+            int batt = GetBatteryLevel();
+            int shutter = shutter_count;
+            int temp = efic_temp;
+            int lv = 0;
+            uint32_t *evf = (uint32_t *)0x7CFEC;
+            if (evf) lv = (*evf != 0);
+            rlen = snprintf(resp, sizeof(resp),
+                "STAT b=%d s=%d t=%d lv=%d rmt=%d cam=70D fw=1.1.2",
+                batt, shutter, temp, lv, remote_shot_flag);
+            send_resp(client_fd, resp, rlen);
+            break;
+        }
+
+        case 'R':
+            call("FA_RemoteRelease");
+            rlen = snprintf(resp, sizeof(resp), "REMOTE_OK");
+            send_resp(client_fd, resp, rlen);
+            break;
+
+        case 'L': {
+            uint32_t *evf = (uint32_t *)0x7CFEC;
+            if (evf && *evf)
+                call("FA_StopLiveView");
+            else
+                call("FA_StartLiveView");
+            rlen = snprintf(resp, sizeof(resp), "LV_TOGGLE");
+            send_resp(client_fd, resp, rlen);
+            break;
+        }
+
+        case 'B':
+            rlen = snprintf(resp, sizeof(resp), "ERR_UNSAFE_CMD");
+            send_resp(client_fd, resp, rlen);
+            break;
+
+        case 'Q':
+            return;
+
+        default:
+            rlen = snprintf(resp, sizeof(resp), "ERR_UNKNOWN_CMD");
+            send_resp(client_fd, resp, rlen);
+            break;
+        }
+    }
+}
+
+/* ── Server task ── */
+
+static void server_task(void *unused)
+{
+    (void)unused;
+
+    int verified = init_socket_ptrs();
+    if (verified < 4) {
+        printf("[%s] Socket ptrs invalid (%d/6), aborting\n", MODNAME, verified);
+        return;
+    }
+    printf("[%s] Socket ptrs: %d/6 valid\n", MODNAME, verified);
+
+    int port = DEFAULT_PORT;
+    read_config(&port);
+    printf("[%s] Starting server on port %d\n", MODNAME, port);
+
+    int sock = p_socket_create(1, SOCK_STREAM, 0);
+    if (sock < 0) {
+        printf("[%s] socket_create failed: %d\n", MODNAME, sock);
+        return;
+    }
+    printf("[%s] socket=%d\n", MODNAME, sock);
+
+    int reuse = 1;
+    p_socket_setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sin_family = SOCK_FAMILY_IPv4;
+    sa.sin_port = htons_ml((uint16_t)port);
+    sa.sin_addr = 0;
+
+    int ret = p_socket_bind(sock, &sa, sizeof(sa));
+    if (ret < 0) {
+        printf("[%s] bind failed: %d\n", MODNAME, ret);
+        socket_close_caller(sock);
+        return;
+    }
+    printf("[%s] bind OK\n", MODNAME);
+
+    ret = p_socket_listen(sock, BACKLOG);
+    if (ret < 0) {
+        printf("[%s] listen failed: %d\n", MODNAME, ret);
+        socket_close_caller(sock);
+        return;
+    }
+    printf("[%s] listen OK, waiting for connections...\n", MODNAME);
+    bmp_printf(FONT_MED, 0, 30, "[%s] Listening on :%d", MODNAME, port);
+
+    TASK_LOOP {
+        int client = ptpip_sock_accept(sock);
+        if (client < 0) {
+            printf("[%s] accept failed: %d\n", MODNAME, client);
+            msleep(1000);
+            continue;
+        }
+
+        printf("[%s] Client connected\n", MODNAME);
+        bmp_printf(FONT_MED, 0, 50, "[%s] Client connected", MODNAME);
+
+        handle_client(client);
+        socket_close_caller(client);
+        printf("[%s] Client disconnected\n", MODNAME);
+        bmp_printf(FONT_MED, 0, 50, "[%s] Waiting for client...", MODNAME);
+
+        msleep(100);
+    }
+}
+
+/* ── Module lifecycle ── */
+
+static unsigned int wifisrv_init(void)
+{
+    printf("[%s] Module loading\n", MODNAME);
+    task_create(MODNAME, 0x1d, 0x2000, server_task, 0);
+    return 0;
+}
+
+static unsigned int wifisrv_deinit(void)
+{
+    printf("[%s] Module unloading\n", MODNAME);
+    return 0;
+}
+
+MODULE_INFO_START()
+    MODULE_INIT(wifisrv_init)
+    MODULE_DEINIT(wifisrv_deinit)
+MODULE_INFO_END()

--- a/platform/70D.112/modules.included
+++ b/platform/70D.112/modules.included
@@ -18,4 +18,12 @@ mlv_snd
 pic_view
 sd_uhs
 selftest
+sf_dump
 silent
+hw_test
+wifi_test
+raw_vidx
+ptptun
+wifisrv
+adtglog2
+ramdump

--- a/platform/70D.112/stubs.S
+++ b/platform/70D.112/stubs.S
@@ -67,7 +67,7 @@ NSTUB(0xFF0D97AC,  gui_main_task)
 /** ASIF **/
 NSTUB(0xFF14169C,  PowerAudioOutput)
 NSTUB(0xFF13FDE0,  PowerMicAmp)                             /* present on 650D.104, EOSM.202, 700D.113 */
-// NSTUB(0xFF11970C,  SetAudioVolumeIn)
+NSTUB(0xFF11970C,  SetAudioVolumeIn)
 NSTUB(0xFF13F728,  SetAudioVolumeOut)
 NSTUB(0xFF117DFC,  SetNextASIFADCBuffer)
 NSTUB(0xFF117FE4,  SetNextASIFDACBuffer)
@@ -78,14 +78,15 @@ NSTUB(0xFF117934,  StopASIFDMADAC)
 NSTUB(0xFF11758C,  StopASIFDMAADC)
 NSTUB(0xFF11936C,  SoundDevActiveIn)
 NSTUB(0xFF1195C4,  SoundDevShutDownIn)
-// NSTUB(    ???,  SetASIFMode)                             /* present on 700D.113 */
+// NSTUB(    ???,  SetASIFMode)                             /* present on 700D.113 (0xFF109510) and 6D.116 (0xFF11CD44) */
+                                                             /* 70D address unknown - need to search _audio_ic_read/write callers */
 
 /** Audio **/
 NSTUB(   0x7B1F8,  sounddev)
 NSTUB(0xFF13F208, _audio_ic_read)
 NSTUB(0XFF13ED44, _audio_ic_write)
 NSTUB(0xFFA1844C,  audio_thresholds)
-// NSTUB(0xFF11936C,  sounddev_active_in)                      /* This one now calls another function, maybe canon refactored the common code path */
+NSTUB(0xFF11936C,  sounddev_active_in)                      /* same as SoundDevActiveIn */
 NSTUB(0xFF118F5C,  sounddev_task)
 
 /** Bitmap **/
@@ -119,8 +120,54 @@ NSTUB(0xFF55CA40,  LiveViewApp_handler)
 NSTUB(0xFF55F1CC,  LiveViewApp_handler_end)
 NSTUB(0xFF55D838,  LiveViewApp_handler_BL_JudgeBottomInfoDispTimerState)
 NSTUB(0xFF745794,  LiveViewShutterApp_handler)
-NSTUB(0xFF7523B4,  LiveViewWifiApp_handler)
-NSTUB(0xFF6EEB9C,  LiveViewLevelApp_handler)
+NSTUB(0xFF7523B4, LiveViewWifiApp_handler)
+
+/** WiFi/Socket API (70D - DIGIC V) **/
+/* Architecture: Socket functions are RAM-loaded from firmware module space at 0x0005xxxx */
+/* (loaded by DryOS at boot, NOT at fixed ROM addresses). Use WEAK_FUNC + direct         */
+/* function pointers in modules. Only socket_close is in ROM1.                            */
+/* See: modules/wifi_test/wifi_test.c for runtime verification pattern                    */
+/*                                                                                        */
+/* Socket API (RAM-loaded 0x0005xxxx - use direct fn pointers with runtime verify):      */
+/*   socket_create:   0x00059AF8  (24 callers, args: domain=1, type=1, protocol=0)       */
+/*   socket_bind:     0x00059E94  (3 callers)                                            */
+/*   socket_connect:  0x00059DDC  (8 callers)                                            */
+/*   socket_listen:   0x0005A9D0  (9 callers, args: fd, backlog)                         */
+/*   socket_accept:   0x00059CE8  (13 callers - may be recvvar)                          */
+/*   socket_recv:     0x00059CE8  (13 callers)                                           */
+/*   socket_send:     0x0005A09C  (30 callers)                                           */
+/*   socket_setsockopt: 0x0005A810 (47 callers - most widely used)                       */
+/*   socket_close:    0xFF14F74C  (3 callers - CONFIRMED in ROM1!)                       */
+/*   socket():        0x00059D60  (4 callers - raw syscall)                              */
+/*                                                                                        */
+/* WiFi Management (RAM-loaded):                                                         */
+/*   nif_setup/NW commands: 0x0005D708 (6 callers)                                       */
+/*   set_IP_address: see NW command strings at 0xFF46CCD8 in ROM1                        */
+/*   wlan_connect: not found - may use NW dispatch or call() interface                   */
+/*                                                                                        */
+/* NwLimeInit/NwLimeOn: NOT found in 70D ROM1 (different arch than 200D DIGIC 8).        */
+/* Use call() to try eventprocs at runtime.                                              */
+/*                                                                                        */
+/* PTPIP socket wrappers (ROM1, safer than calling 0x0005xxxx directly):                 */
+/* Full PTPIP SU (Socket Utility) module at 0xFF7AEE00-0xFF7AF500                      */
+/* These are ROM1-resident wrappers with error handling, logging, proper param setup.   */
+/*                                                                                       */
+/* Socket API:                                                                          */
+NSTUB(0xFF14F74C, socket_close_caller)
+NSTUB(0xFF7AF380, socket_close_if_valid)       /* close(fd) if fd != -1, else noop           */
+/*                                                                                       */
+/* PTPIP Socket Wrappers (safe, ROM1-resident, include error handling + logging):      */
+NSTUB(0xFF7AF220, ptpip_sock_create)           /* socket_create(1,1,0) + setsockopt REUSEADDR */
+NSTUB(0xFF7AEE18, ptpip_bind_param)            /* socket() + bind + socket_close on error     */
+NSTUB(0xFF7AEE80, ptpip_open_server)           /* Full TCP server: socket+bind+setopt+log     */
+NSTUB(0xFF7AF160, ptpip_sock_accept)           /* accept client connection, returns client fd */
+NSTUB(0xFF7AF2CC, ptpip_create_client)         /* TCP client: connect from sockaddr struct     */
+NSTUB(0xFF7AEFCC, ptpip_listen_close)          /* listen(1) + socket_close_caller             */
+NSTUB(0xFF7AF344, ptpip_close_server)          /* listen(2,shutdown) + socket_close_caller    */
+NSTUB(0xFF7AF38C, ptpip_set_keepalive)         /* setsockopt(SO_KEEPALIVE=1) helper           */
+NSTUB(0xFF7AF3B4, ptpip_errno_handler)         /* Print "[PTPIP] SU: errno=%d" with DryOS errno */
+
+NSTUB(0xFF6EEB9C, LiveViewLevelApp_handler)
 NSTUB(0xFF776250,  PlayMain_handler) // old StopPlayTouchPassFilterApp_handler
 NSTUB(0xFF5886E0,  PlayMovieGuideApp_handler)
 NSTUB(0xFF56A160,  ShootOlcApp_handler)
@@ -184,7 +231,7 @@ NSTUB(    0x8094,  SetHPTimerNextTick)
 
 /** H264 Encoder **/
 NSTUB(   0x946E0,  mvr_config)
-NSTUB(0xFF2BB65C,  mvrFixQScale)                            // FIXME: use call()
+NSTUB(0xFF2BB65C,  mvrFixQScale)                            // verified ROM address; also works via call("mvrFixQScale")
 NSTUB(0xFF2BB154,  mvrSetDefQScale)
 NSTUB(0xFF2BB18C,  mvrSetFullHDOptSize)
 NSTUB(0xFF2BB370,  mvrSetGopOptSizeFULLHD)

--- a/src/ptp-chdk.c
+++ b/src/ptp-chdk.c
@@ -569,9 +569,28 @@ PTP_HANDLER( PTP_OC_CHDK, 0 )
             break;
 
         case PTP_CHDK_ExecuteScript:
-            bmp_printf(FONT_LARGE, 0, 0, "ExecuteScript: not implemented");
-            msleep(1000);
-            break;
+            {
+                int script_len = context->get_data_size(context->handle);
+                if (script_len > 0) {
+                    char *script = fio_malloc(script_len + 1);
+                    if (script) {
+                        if (recv_ptp_data(context, script, script_len)) {
+                            script[script_len] = 0;
+                            FILE *f = FIO_CreateFile("ML/SCRIPTS/CHDK_RUN.LUA");
+                            if (f) {
+                                FIO_WriteFile(f, script, script_len);
+                                FIO_CloseFile(f);
+                                bmp_printf(FONT_LARGE, 0, 0, "Script saved (%d bytes)", script_len);
+                            } else {
+                                bmp_printf(FONT_LARGE, 0, 0, "ExecuteScript: cannot create file");
+                            }
+                        }
+                        fio_free(script);
+                    }
+                }
+                msg.param_count = 1;
+                msg.param[0] = 0;
+            }
 
         default:
             msg.id = PTP_RC_ParameterNotSupported;


### PR DESCRIPTION
I wanted to get this code in front of the community even though it is not fully working yet. The 70D is the only DIGIC V camera with built-in WiFi, and Canon's firmware initializes the full networking stack at boot. The socket API functions are loaded into RAM (confirmed at 0x0005xxxx by hw_test). The PTPIP stubs are ROM1-resident (confirmed at 0xFF7Axxxx). But I have not been able to test the actual WiFi connection yet.

This PR includes:
- 11 PTPIP NSTUBs in stubs.S for the ROM1 function addresses
- wifisrv module: a TCP server skeleton on port 5555 using the RAM-loaded socket functions. The 'B' command (EnableBootDisk) was removed -- that call freezes the 70D.
- wifi_test module: probes WiFi capability at module load
- ptptun module: a PTP tunnel at opcode 0xA1E9 with 8 commands (CallByName, Screenshot, ExecuteLua, EngioRead/Write, ShamemRead, SetPropertyRaw). The EnableBootDisk and TurnOnDisplay calls in the self-test were removed since both freeze the camera.
- ptp-chdk.c fix: the ExecuteScript handler now saves Lua to ML/SCRIPTS/CHDK_RUN.LUA

This is ongoing work and will require more detailed testing on my end.