### PR TITLE
WIP: setup 1500D Cache Hack config, stuck at struct task error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
-Magic Lantern
+Magic Lantern Simplified - Canon 1500D / 2000D Fork
 =============
 
-Magic Lantern (ML) is a software enhancement that offers increased
-functionality to the excellent Canon DSLR cameras.
+**⚠️ EXPERIMENTAL FORK / WORK IN PROGRESS ⚠️**
+
+This repository is a dedicated fork of the [magiclantern_simplified](https://github.com/reticulatedpines/magiclantern_simplified) project. The primary goal of this fork is to bring Magic Lantern support to the **Canon EOS 1500D / 2000D / Rebel T7 (DIGIC 4+)**.
+
+### Current Active Development
+* **Target Cameras:** Canon 1500D / 2000D / Rebel T7
+* **Firmware Version:** `1.3.0`
+* **Method:** Cache Hack (`minimal` profile porting)
+* **Status:** Early porting stage (Memory mapping, Bootloader hijacking, defining DryOS structures).
+
+If you are a developer looking to contribute to the 1500D port, please check the ongoing commits or open issues.
+
+---
+
+### About Magic Lantern
+Magic Lantern (ML) is a software enhancement that offers increased functionality to the excellent Canon DSLR cameras.
   
-It's an open framework, licensed under GPL, for developing extensions to the
-official firmware.
+It's an open framework, licensed under GPL, for developing extensions to the official firmware.
 
-Magic Lantern is not a *hack*, or a modified firmware, **it is an
-independent program that runs alongside Canon's own software**. 
-Each time you start your camera, Magic Lantern is loaded from your memory
-card. Our only modification was to enable the ability to run software
-from the memory card.
+Magic Lantern is not a *hack*, or a modified firmware, **it is an independent program that runs alongside Canon's own software**. 
+Each time you start your camera, Magic Lantern is loaded from your memory card. Our only modification was to enable the ability to run software from the memory card.
 
-ML is being developed by photo and video enthusiasts, adding
-functionality such as: HDR images and video, timelapse, motion
-detection, focus assist tools, manual audio controls much more.
+ML is being developed by photo and video enthusiasts, adding functionality such as: HDR images and video, timelapse, motion detection, focus assist tools, manual audio controls much more.
 
 For more details on Magic Lantern please see [http://www.magiclantern.fm/](http://www.magiclantern.fm/)
 
-There is a sibling repo for our patched version of Qemu that adds support
-for emulating camera ROMs. This allows testing without access to a physical
-camera, and automating tests across a suite of cameras.  
+There is a sibling repo for our patched version of Qemu that adds support for emulating camera ROMs. This allows testing without access to a physical camera, and automating tests across a suite of cameras.  
 https://github.com/reticulatedpines/qemu-eos  
 https://github.com/reticulatedpines/qemu-eos/tree/qemu-eos-v4.2.1 (current ML team supported branch)

--- a/platform/1500D.130/Makefile
+++ b/platform/1500D.130/Makefile
@@ -1,0 +1,22 @@
+MODEL = 1500D
+FW_VERSION = 130
+
+TOP_DIR = ../..
+
+# Arsitektur Prosesor (Wajib untuk DIGIC 4+)
+PLATFORM_ARCH = armv5te
+
+# Profil Kompilasi (Tes nyawa awal)
+ML_SRC_PROFILE = minimal
+CFLAGS += -Wno-error
+
+# Konfigurasi Memori & Cache Hack 1500D (ROM 32MB)
+MAIN_FIRMWARE_ADDR = 0xFE0C0000
+ROMBASEADDR = 0xFE0C0000
+RESTARTSTART = 0xC80000
+ML_BOOT_OBJ = boot-d45-ch.o
+
+# Jembatan Kompilasi
+include ../Makefile
+
+.DEFAULT_GOAL := $(BUILD_DIR)/cam_complete

--- a/platform/1500D.130/Makefile.platform.default
+++ b/platform/1500D.130/Makefile.platform.default
@@ -1,0 +1,27 @@
+# 1500D 1.3.0
+
+CANON_NAME_FIR      = CCF26130.FIR
+FIRMWARE_ID         = 0x80000432
+
+# Identitas Kamera
+MODEL = 1500D
+FW_VERSION = 130
+
+# Profil kompilasi awal (wajib minimal untuk tes nyawa)
+ML_SRC_PROFILE = minimal
+CFLAGS += -Wno-error
+
+# Konfigurasi Cache Hack (Sangat Krusial)
+ROMBASEADDR = 0xFE0C0000
+RESTARTSTART = 0xC80000
+ML_BOOT_OBJ = boot-d45-ch.o
+
+# 32MB ROM, like 1300D
+ROMBASEADDR         = 0xFE0C0000
+PLATFORM_ARCH = armv5te
+# Load ML at the end of the AllocateMemory pool
+# Default 0x2D0000 - 0xD00000, patched to 0x2D0000 - 0xC80000 (512K for us).
+RESTARTSTART        = 0xC80000
+ML_BOOT_OBJ         = boot-d45-ch.o
+ML_SRC_EXTRA_OBJS += function_overrides.o
+

--- a/platform/1500D.130/Makefile.setup.default
+++ b/platform/1500D.130/Makefile.setup.default
@@ -1,0 +1,7 @@
+#Makefile for 2000D
+
+TOP_DIR=../..
+ML_AF_PATTERNS_OBJ = n
+
+# 2000D_101.sym is to long
+ML_MODULES_SYM_NAME=t7_$(FW_VERSION).sym

--- a/platform/1500D.130/cfn.c
+++ b/platform/1500D.130/cfn.c
@@ -1,0 +1,17 @@
+#include <dryos.h>
+#include <property.h>
+#include <cfn-generic.h>
+
+// look on camera menu or review sites to get custom function numbers
+
+int get_htp() { return GetCFnData(0, 5); }
+void set_htp(int value) { SetCFnData(0, 5, value); }
+
+// No MLU on the 1300D :(
+int get_mlu() { return 0; }
+void set_mlu(int value) { return; }
+
+int cfn_get_af_button_assignment() { return GetCFnData(0, 7); }
+void cfn_set_af_button(int value) { SetCFnData(0, 7, value); }
+
+GENERIC_GET_ALO

--- a/platform/1500D.130/consts.h
+++ b/platform/1500D.130/consts.h
@@ -1,0 +1,282 @@
+/*
+ *  2000D 1.1.0 consts
+ */
+
+#define CANON_SHUTTER_RATING 100000
+
+#define CARD_LED_ADDRESS 0xC0220134 // http://magiclantern.wikia.com/wiki/Led_addresses
+#define LEDON 0x46
+#define LEDOFF 0x44
+
+#define HIJACK_CACHE_HACK
+
+#define HIJACK_CACHE_HACK_BSS_END_ADDR   0xfe0c1b74
+#define HIJACK_CACHE_HACK_BSS_END_INSTR  0xE3A01732 // should be the correct INSTRUCTION MOV R1, 0xc80000
+#define HIJACK_CACHE_HACK_INITTASK_ADDR  0xfe0c3b34
+
+#define HIJACK_INSTR_BL_CSTART  0xfe0c0638
+#define HIJACK_INSTR_BSS_END 0xfe0c3b24
+#define HIJACK_FIXBR_BZERO32 0xfe0c3a6c
+#define HIJACK_FIXBR_CREATE_ITASK 0xfe0c3b0c
+#define HIJACK_INSTR_MY_ITASK 0xfe0c3b34
+/* new-style DryOS hooks? */
+//#define HIJACK_TASK_ADDR 0x31170  // ok
+
+//#define ARMLIB_OVERFLOWING_BUFFER 0x310A8 //0x167FC // in AJ_armlib_setup_related3 // this is deactivated in config for this camera, maybe we need to activate it again
+
+#define DRYOS_ASSERT_HANDLER 0x35888 // ok// dec TH_assert or assert_0 // not sure
+#define MVR_992_STRUCT (*(void**)(0x315dc+0x4)) // ok look in MVR_Initialize for AllocateMemory call
+
+#define div_maybe(a,b) ((a)/(b))
+#define MVR_BUFFER_USAGE_FRAME ABS(div_maybe(-100*MEM(356 + MVR_992_STRUCT) - 100*MEM(364 + MVR_992_STRUCT) - 100*MEM(952 + MVR_992_STRUCT) - 100*MEM(960 + MVR_992_STRUCT) + 100*MEM(360 + MVR_992_STRUCT) + 100*MEM(368 + MVR_992_STRUCT), -MEM(356 + MVR_992_STRUCT) - MEM(364 + MVR_992_STRUCT) + MEM(360 + MVR_992_STRUCT) + MEM(368 + MVR_992_STRUCT)))
+#define MVR_BUFFER_USAGE_SOUND div_maybe(-100*MEM(544 + MVR_992_STRUCT) + 100*MEM(532 + MVR_992_STRUCT), 0xa)
+#define MVR_BUFFER_USAGE MAX(MVR_BUFFER_USAGE_FRAME, MVR_BUFFER_USAGE_SOUND)
+
+#define MVR_FRAME_NUMBER (*(int*)(332 + MVR_992_STRUCT)) // in mvrSMEncodeDone 0x14C=332
+#define MVR_BYTES_WRITTEN MEM((296 + MVR_992_STRUCT)) //in mvrSMEncodeDone
+
+#define MOV_RES_AND_FPS_COMBINATIONS 9
+#define MOV_OPT_NUM_PARAMS 2
+#define MOV_GOP_OPT_NUM_PARAMS 5
+#define MOV_OPT_STEP 5
+#define MOV_GOP_OPT_STEP 5
+
+
+ #define AUDIO_MONITORING_HEADPHONES_CONNECTED 0
+//#define HOTPLUG_VIDEO_OUT_PROP_DELIVER_ADDR 0x1a8c // this prop_deliver performs the action for Video Connect and Video Disconnect  // not present on 1300D (see FE0C69C8: taskHotPlug)
+//#define HOTPLUG_VIDEO_OUT_STATUS_ADDR 0x1ac4 // passed as 2nd arg to prop_deliver; 1 = display connected, 0 = not, other values disable this event (trick)  // not present on 1300D (see FE0C69C8: taskHotPlug)
+
+
+// 720x480, changes when external monitor is connected
+ #define YUV422_LV_BUFFER_1 0x40d07800 
+ #define YUV422_LV_BUFFER_2 0x4c233800
+ #define YUV422_LV_BUFFER_3 0x4f11d800
+ 
+ #define REG_EDMAC_WRITE_LV_ADDR 0xc0f04308 // SDRAM address of LV buffer (aka VRAM)
+ #define REG_EDMAC_WRITE_HD_ADDR 0xc0f04208 // SDRAM address of HD buffer (aka YUV)
+
+#define YUV422_LV_BUFFER_DISPLAY_ADDR (*(uint32_t*)0x318C8)  // ok 0x31818+0xB0
+#define YUV422_HD_BUFFER_DMA_ADDR (shamem_read(REG_EDMAC_WRITE_HD_ADDR))
+
+// changes during record
+ #define YUV422_HD_BUFFER_1 0x44000080
+ #define YUV422_HD_BUFFER_2 0x46000080
+ #define YUV422_HD_BUFFER_3 0x48000080
+ #define YUV422_HD_BUFFER_4 0x4e000080
+ #define YUV422_HD_BUFFER_5 0x50000080
+#define FOCUS_CONFIRMATION (*(int*)(0x36e20 + 0x4)) // ok see "focusinfo" and Wiki:Struct_Guessing
+#define HALFSHUTTER_PRESSED (*(int*)(0x359A4 + 0x1C)) //ok look for string "[MC] permit LV instant"
+#define DISPLAY_SENSOR_POWERED (*(int*)(0x359A0 + 0x18))  //ok Look up *"ForceDisableDisplay (%d)"
+
+// for gui_main_task
+#define GMT_NFUNCS 7
+//de verificat
+#define GMT_FUNCTABLE 0xFE851F20 // dec gui_main_task
+
+
+
+
+#define LV_BOTTOM_BAR_DISPLAYED (((*(int8_t*)0x3830C) == 0xF) || ((*(int8_t*)0x3FE14) != 0x17))
+#define LV_BOTTOM_BAR_STATE (*(uint8_t*)0x3AA80) // in JudgeBottomInfoDispTimerState, if bottom bar state is 2, Judge returns 0; ML will make it 0 to hide bottom bar
+#define ISO_ADJUSTMENT_ACTIVE ((*(int*)0x3830C) == 0xF)
+#define SHOOTING_MODE (*(int*)0x35930)
+#define UNAVI_FEEDBACK_TIMER_ACTIVE (MEM(0x3fc74) != 0x17) //ok dec CancelUnaviFeedBackTimer
+
+ 
+
+
+
+ 
+ #define AE_STATE (*(int8_t*)(0x3AA80 + 0x1C))
+ #define AE_VALUE (*(int8_t*)(0x3AA80 + 0x1D))
+
+#define CURRENT_GUI_MODE (*(int*)0x36560) // ok GUIMode_maybe 0x36478 + 0x48
+    	// from a screenshot
+#define COLOR_FG_NONLV 80
+//#define COLOR_FG_NONLV 1
+#define GUIMODE_WB 5
+#define GUIMODE_FOCUS_MODE 9
+#define GUIMODE_DRIVE_MODE 8
+#define GUIMODE_PICTURE_STYLE 4
+
+#define GUIMODE_PLAY 1
+#define GUIMODE_MENU 2
+#define GUIMODE_Q_UNAVI 0x1F
+#define GUIMODE_FLASH_AE 0x22
+#define GUIMODE_PICQ 6
+ #define GUIMODE_MOVIE_ENSURE_A_LENS_IS_ATTACHED (CURRENT_GUI_MODE == 0x1e)
+ #define GUIMODE_MOVIE_PRESS_LV_TO_RESUME (CURRENT_GUI_MODE == 0x1f)
+//~ #define GUIMODE_MOVIE_ENSURE_A_LENS_IS_ATTACHED 0 // not good
+//~ #define GUIMODE_MOVIE_PRESS_LV_TO_RESUME 0
+
+ #define PLAY_MODE (gui_state == GUISTATE_PLAYMENU && CURRENT_GUI_MODE == GUIMODE_PLAY)
+ #define MENU_MODE (gui_state == GUISTATE_PLAYMENU && CURRENT_GUI_MODE == GUIMODE_MENU)
+
+
+
+// position for ML ISO disp outside LV
+#define MENU_DISP_ISO_POS_X 527
+#define MENU_DISP_ISO_POS_Y 45
+
+//position for ML MAX ISO
+#define MAX_ISO_POS_X 590
+#define MAX_ISO_POS_Y 28
+
+// for ML hdr display
+#define HDR_STATUS_POS_X 562
+#define HDR_STATUS_POS_Y 100
+
+//for HTP mode on display
+#define HTP_STATUS_POS_X 500
+#define HTP_STATUS_POS_Y 233
+
+//for Mirror Lock Up enabled on display
+#define MLU_STATUS_POS_X 316
+#define MLU_STATUS_POS_Y 310
+
+#define WBS_GM_POS_X 365
+#define WBS_GM_POS_Y 230
+
+#define WBS_POS_X 365
+#define WBS_POS_Y 260
+
+// Audio remote shot position info photo mode
+#define AUDIO_REM_SHOT_POS_X 200
+#define AUDIO_REM_SHOT_POS_Y 386
+
+// position for displaying clock outside LV
+#define DISPLAY_CLOCK_POS_X 440
+#define DISPLAY_CLOCK_POS_Y 400
+
+#define DISPLAY_DATE_POS_X 425
+#define DISPLAY_DATE_POS_Y 430
+
+#define DISPLAY_BATTERY_POS_X 350
+#define DISPLAY_BATTERY_POS_Y 400
+
+// position for displaying K icon in photo info display
+#define WB_K_ICON_POS_X 307
+#define WB_K_ICON_POS_Y 226
+
+// position for displaying K values in photo info display
+#define WB_KELVIN_POS_X 307
+#define WB_KELVIN_POS_Y 260
+
+// position for displaying card size remain outside LV
+#define DISPLAY_GB_POS_X 305
+#define DISPLAY_GB_POS_Y 410
+
+// for displaying TRAP FOCUS msg outside LV
+#define DISPLAY_TRAP_FOCUS_POS_X 65
+#define DISPLAY_TRAP_FOCUS_POS_Y 360
+#define DISPLAY_TRAP_FOCUS_MSG       "TRAP FOCUS"
+#define DISPLAY_TRAP_FOCUS_MSG_BLANK "          "
+
+// In bindGUIEventFromGUICBR, look for "LV Set" => arg0 = 8 -> 1300D are val 6
+// Next, in SetGUIRequestMode, look at what code calls NotifyGUIEvent(8, something)
+//#define GUIMODE_ML_MENU (RECORDING ? 0 : lv ? 68 : 2)
+// skip RECORDING variant for now
+#define GUIMODE_ML_MENU (lv ? 68 : 2)
+
+#define NUM_PICSTYLES 10
+
+
+#define FLASH_MAX_EV 3
+#define FLASH_MIN_EV -5
+#define FASTEST_SHUTTER_SPEED_RAW 152
+#define MAX_AE_EV 5
+#define DIALOG_MnCardFormatBegin   (0x462c8+4) // ret_CreateDialogBox(...DlgMnCardFormatBegin_handler...) is stored there
+#define DIALOG_MnCardFormatExecute (0x49c4c+4) // ret_CreateDialogBox(...DlgMnCardFormatBegin_handler...) is stored there
+#define FORMAT_BTN_NAME "[Q]"
+#define FORMAT_BTN BGMT_Q
+#define FORMAT_STR_LOC 11
+
+#define BULB_MIN_EXPOSURE 1000
+
+// http://magiclantern.wikia.com/wiki/Fonts
+#define BFNT_CHAR_CODES    0xff23eac8
+#define BFNT_BITMAP_OFFSET 0xff241a08
+#define BFNT_BITMAP_DATA   0xff244944
+// from CFn
+#define AF_BTN_HALFSHUTTER 0
+#define AF_BTN_STAR 1
+
+#define IMGPLAY_ZOOM_LEVEL_ADDR (0x3affc+12) // dec GuiImageZoomDown and look for a negative counter
+#define IMGPLAY_ZOOM_LEVEL_MAX 14
+#define IMGPLAY_ZOOM_POS_X MEM(0x6f9b8) // Zoom CentrePos Look up *"CentrePos x:%ld y:%ld"
+#define IMGPLAY_ZOOM_POS_Y MEM(0x6f9b8+0x4) // Look up *"CentrePos x:%ld y:%ld"
+#define IMGPLAY_ZOOM_POS_X_CENTER 0x144
+#define IMGPLAY_ZOOM_POS_Y_CENTER 0xd8
+#define IMGPLAY_ZOOM_POS_DELTA_X (0x144 - 0x93)
+#define IMGPLAY_ZOOM_POS_DELTA_Y (0xd8 - 0x7d)
+
+#define BULB_EXPOSURE_CORRECTION 100 // min value for which bulb exif is OK [not tested]
+
+#define WINSYS_BMP_DIRTY_BIT_NEG MEM(0x3da10+0x2C) // see http://magiclantern.wikia.com/wiki/VRAM/BMP
+
+// manual exposure overrides
+#define LVAE_STRUCT 0x3B7A4  //ok
+#define CONTROL_BV      (*(uint16_t*)(LVAE_STRUCT+0x1c)) // ok EP_SetControlBv old 1c
+#define CONTROL_BV_TV   (*(uint16_t*)(LVAE_STRUCT+0x1e)) // EP_SetControlParam
+#define CONTROL_BV_AV   (*(uint16_t*)(LVAE_STRUCT+0x20))
+#define CONTROL_BV_ISO  (*(uint16_t*)(LVAE_STRUCT+0x22))
+#define CONTROL_BV_ZERO (*(uint16_t*)(LVAE_STRUCT+0x24))
+#define LVAE_ISO_SPEED  (*(uint8_t* )(LVAE_STRUCT))      // offset 0x0; at 3 it changes iso very slowly
+#define LVAE_ISO_MIN    (*(uint8_t* )(LVAE_STRUCT+0x2a)) // string: ISOMin:%d ???
+#define LVAE_ISO_HIS    (*(uint8_t* )(LVAE_STRUCT+0x2c)) // no idea what this is
+#define LVAE_DISP_GAIN  (*(uint16_t*)(LVAE_STRUCT+0x26)) // lvae_setdispgain
+#define LVAE_MOV_M_CTRL (*(uint8_t* )(LVAE_STRUCT+0x78)) // lvae_setmoviemanualcontrol
+
+#define DISPLAY_ORIENTATION MEM(0x31818+0x7C) // read-only; string: UpdateReverseTFT
+
+#define MIN_MSLEEP 20
+
+#define INFO_BTN_NAME "DISP"
+#define Q_BTN_NAME (RECORDING ? "INFO" : "[Q]")
+#define ARROW_MODE_TOGGLE_KEY ""
+
+#define DISPLAY_STATEOBJ (*(struct state_object **)0x318B8)  //0x31818+0xa0
+#define DISPLAY_IS_ON (DISPLAY_STATEOBJ->current_state != 0)
+
+#define VIDEO_PARAMETERS_SRC_3 0x6a5d4 
+#define FRAME_SHUTTER_TIMER (*(uint16_t*)(VIDEO_PARAMETERS_SRC_3+0xC))
+#define FRAME_ISO (*(uint8_t*)(VIDEO_PARAMETERS_SRC_3+0x8))
+#define FRAME_APERTURE (*(uint8_t*)(VIDEO_PARAMETERS_SRC_3+0x9))
+#define FRAME_SHUTTER (*(uint8_t*)(VIDEO_PARAMETERS_SRC_3+0xa))
+#define FRAME_BV ((int)FRAME_SHUTTER + (int)FRAME_APERTURE - (int)FRAME_ISO)
+
+#define FRAME_SHUTTER_BLANKING_ZOOM   (*(uint16_t*)0x40481B20) // ADTG register 805f
+#define FRAME_SHUTTER_BLANKING_NOZOOM (*(uint16_t*)0x40481B24) // ADTG register 8061
+#define FRAME_SHUTTER_BLANKING_READ   (lv_dispsize > 1 ? FRAME_SHUTTER_BLANKING_NOZOOM : FRAME_SHUTTER_BLANKING_ZOOM) /* when reading, use the other mode, as it contains the original value (not overriden) */
+#define FRAME_SHUTTER_BLANKING_WRITE  (lv_dispsize > 1 ? &FRAME_SHUTTER_BLANKING_ZOOM : &FRAME_SHUTTER_BLANKING_NOZOOM)
+//#define LV_DISP_MODE (MEM(0x66b00 + 0x24) != 3) //on EOSM is (MEM(0x89BAC + 0x7C) != 3)// 00067548
+
+// see "Malloc Information"
+#define MALLOC_STRUCT 0x66760
+#define MALLOC_FREE_MEMORY (MEM(MALLOC_STRUCT + 8) - MEM(MALLOC_STRUCT + 0x1C)) // "Total Size" - "Allocated Size"
+#define SRM_BUFFER_SIZE 0x1f68000 //0x14E8000   /* print it from srm_malloc_cbr */
+
+
+// for bulb ramping calibration: delay between two exposure readings (increase it if brightness updates slowly)
+// if not defined, default is 500
+#define BRAMP_CALIBRATION_DELAY 1000
+
+//~ max volume supported for beeps
+#define ASIF_MAX_VOL 5
+// look for "JudgeBottomInfoDispTimerState(%d)"
+#define JUDGE_BOTTOM_INFO_DISP_TIMER_STATE	0x3fe5c
+
+// temperature convertion from raw-temperature to celsius
+// http://www.magiclantern.fm/forum/index.php?topic=9673.0
+#define EFIC_CELSIUS ((int)efic_temp * 55 / 100 - 68)
+
+
+#define HIJACK_CACHE_HACK
+#define HIJACK_CACHE_HACK_BSS_END_ADDR 0xfe0c1b74
+#define HIJACK_CACHE_HACK_BSS_END_INSTR 0xE3A01732
+#define HIJACK_CACHE_HACK_INITTASK_ADDR 0xfe0c3b34
+
+#define HIJACK_INSTR_BSS_END 0xfe0c3b24
+#define HIJACK_FIXBR_BZERO32 0xfe0c3a6c
+#define HIJACK_FIXBR_CREATE_ITASK 0xfe0c3b0c
+#define HIJACK_INSTR_MY_ITASK 0xfe0c3b34

--- a/platform/1500D.130/features.h
+++ b/platform/1500D.130/features.h
@@ -1,0 +1,56 @@
+//#define CONFIG_HELLO_WORLD
+
+#include "all_features.h"
+
+
+//
+//	Nothing can be done in here, commented everything out
+//
+
+
+/* Can't Be Implemented */
+
+//#define FEATURE_DIGITAL_ZOOM_SHORTCUT
+//#define FEATURE_LV_3RD_PARTY_FLASH
+//#define FEATURE_FLASH_TWEAKS
+//#define FEATURE_EYEFI_TRICKS
+
+//#define DEBUG_TASK_HOOK
+
+
+//#define FEATURE_INTERMEDIATE_ISO_PHOTO_DISPLAY
+
+//#undef FEATURE_FLEXINFO
+
+//#undef FEATURE_SHOW_TASKS
+//#undef FEATURE_SHOW_CPU_USAGE
+//#undef FEATURE_SHOW_GUI_EVENTS
+
+//#undef FEATURE_SHOW_IMAGE_BUFFERS_INFO
+//#undef FEATURE_SHOW_EDMAC_INFO
+
+//#undef CONFIG_TSKMON
+#undef FEATURE_LV_ZOOM_SETTINGS
+#undef FEATURE_EXPO_ISO
+#undef FEATURE_FPS_OVERRIDE
+////////////////////////
+
+
+#undef FEATURE_FORCE_LIVEVIEW // Already Live View
+#undef FEATURE_MLU // No Mirror
+#undef FEATURE_MLU_HANDHELD
+#undef FEATURE_STICKY_DOF // No DOF button
+#undef FEATURE_IMAGE_EFFECTS // DigicV new effects check "Art Filter"
+#undef FEATURE_INTERMEDIATE_ISO_PHOTO_DISPLAY // Well.. it will work in 1 mode
+#undef FEATURE_AF_PATTERNS // No regular AF
+#undef FEATURE_VOICE_TAGS // Just to be sure
+#undef FEATURE_SHOW_IMAGE_BUFFERS_INFO
+#undef FEATURE_SHOW_EDMAC_INFO
+#undef FEATURE_SHOW_SIGNATURE
+#undef CONFIG_TSKMON
+#undef FEATURE_QUICK_ZOOM
+#define FEATURE_HISTOGRAM
+
+#undef CONFIG_CRASH_LOG
+#undef CONFIG_PROP_REQUEST_CHANGE
+#undef CONFIG_AUTOBACKUP_ROM

--- a/platform/1500D.130/function_overrides.c
+++ b/platform/1500D.130/function_overrides.c
@@ -1,0 +1,32 @@
+// functions 200D/101
+
+// SJE overrides for functions I couldn't find stubs for,
+// as well as ones that I think function sig has changed,
+// so we can define wrappers.
+
+#include <dryos.h>
+#include <property.h>
+#include <bmp.h>
+#include <config.h>
+#include <consts.h>
+#include <lens.h>
+#include <tasks.h>
+
+extern struct task* first_task;
+int get_task_info_by_id(int task_id, void *task_attr)
+{
+    // D678 uses the high half of the ID for some APIs, D45 looks to only
+    // use the low half.  We use the low half as index to find the full value.
+//    printf("[cristi] - in get_task_info_by_id: %x\n", task_id);
+    struct task *task = first_task + (task_id & 0xff);
+    return _get_task_info_by_id(task->taskId, task_attr);
+}
+//void _engio_write(uint32_t* reg_list)
+//{
+//	int param2="";
+//	int param3="";
+//	int param4="";
+//	DryosDebugMsg(0, 15, "Apelez _engio_write2 \n"); 
+ //   return _engio_write2(reg_list, param2, param3, param4);
+//}
+

--- a/platform/1500D.130/gui.h
+++ b/platform/1500D.130/gui.h
@@ -1,0 +1,3 @@
+#ifndef _cameraspecific_gui_h_
+#define _cameraspecific_gui_h_
+#endif

--- a/platform/1500D.130/include/platform/mvr.h
+++ b/platform/1500D.130/include/platform/mvr.h
@@ -1,0 +1,138 @@
+#ifndef __PLATFORM_MVR_H__
+#define __PLATFORM_MVR_H__
+
+// Movie recording.
+// tab size: 4
+// not all values are correct (most of them are for 550D)
+struct mvr_config
+{
+	uint16_t		debug_flag;				// 0x00, 6290, 1 = write debugmsg's OK
+	uint16_t		qscale_mode;			// 0x02, 6292, 1 = QScale, 0 = CBR
+	uint16_t		db_filter_a;			// 0x04, 67c0, no effect
+	uint16_t		db_filter_b;			// 0x06, 67c2, no effect
+	int16_t			def_q_scale;			// 0x08, 67c4, works when qscale_mode = 1
+	int16_t 		qscale_related_1;		// 0x0a, 67c6
+	int16_t 		qscale_related_2;		// 0x0c, 67c8
+	int16_t 		qscale_related_3;		// 0x0e, 67ca
+	int16_t 		qscale_limit_L;			// 0x10, 67cc
+	int16_t 		qscale_limit_H;			// 0x12, 67ce
+	uint16_t		time_const;				// 0x14, 67d0, unknown
+	uint16_t		x67d0;					// 0x16, 67d2
+	uint32_t		fullhd_30fps_opt_size_I;// 0x18, 62a8, works when qscale_mode = 0
+	uint32_t		fullhd_30fps_opt_size_P;// 0x1c, 62ac
+	uint32_t		D1_30fps;				// 0x20, 67dc
+	uint32_t		D2_30fps;				// 0x24, 67e0
+	uint32_t		x67e4;					// 0x28, 67e4
+	uint32_t		fullhd_25fps_opt_size_I;// 0x2c, 67e8 OK
+	uint32_t		fullhd_25fps_opt_size_P;// 0x30, 67ec
+	uint32_t		fullhd_25fps_D1;		// 0x34, 67f0
+	uint32_t		fullhd_25fps_D2;		// 0x38, 67f4
+	uint32_t		x67f8;					// 0x3c, 67f8
+	uint32_t		fullhd_24fps_opt_size_I;// 0x40, 67fc
+	uint32_t		fullhd_24fps_opt_size_P;// 0x44, 6800
+	uint32_t		fullhd_24fps_D1;		// 0x48, 6804
+	uint32_t		fullhd_24fps_D2;		// 0x4c, 6808
+	uint32_t		x680c;					// 0x50, 680c
+	uint32_t		hd_60fps_opt_size_I;	// 0x54, 6810 OK
+	uint32_t		hd_60fps_opt_size_P;	// 0x58, 6814
+	uint32_t		hd_60fps_D1;			// 0x5c, 6818
+	uint32_t		hd_60fps_D2;			// 0x60, 681c
+	uint32_t		x6820;					// 0x64, 6820
+	uint32_t		hd_50fps_opt_size_I;	// 0x68, 6824
+	uint32_t		hd_50fps_opt_size_P;	// 0x6c, 6828
+	uint32_t		hd_50fps_D1;			// 0x70, 682c
+	uint32_t		hd_50fps_D2;			// 0x74, 6830
+	uint32_t		x6834_kinda_counter;	// 0x78, 6834
+	uint32_t		vga_60fps_opt_size_I;	// 0x7c, 6838 nope (it's for other resolution)
+	uint32_t		vga_60fps_opt_size_P;	// 0x80, 683c
+	uint32_t		vga_60fps_D1;			// 0x84, 6840
+	uint32_t		vga_60fps_D2;			// 0x88, 6844
+	uint32_t		x6848;					// 0x8c, 6848
+	uint32_t		vga_50fps_opt_size_I;	// 0x90, 684c
+	uint32_t		vga_50fps_opt_size_P;	// 0x94, 6850
+	uint32_t		vga_50fps_D1;			// 0x98, 6854
+	uint32_t		vga_50fps_D2;			// 0x9c, 6858
+	uint32_t		x685c;					// 0xa0, 685c
+	int32_t 		xa4;					// 0xa4, 6860 here is for VGA
+	int32_t 		xa8;					// 0xa8, 6864
+	int32_t 		xac;					// 0xac, 6868
+	uint32_t		xb0;					// 0xb0, 686c
+	uint32_t		xb4;					// 0xb4, 6870
+	uint32_t		xb8;					// 0xb8, 6874 and here should be the second
+	uint32_t		xbc;					// 0xbc, 6878
+	uint32_t		xc0;					// 0xc0, 687c
+	uint32_t		xc4;					// 0xc4, 6880
+	uint32_t		xc8;					// 0xc8, 6884
+	uint32_t		xcc;					// 0xcc, 6888
+	uint32_t		xd0;					// 0xd0, 688c
+	uint32_t		xd4;					// 0xd4, 6890
+	uint32_t		xd8;					// 0xd8, 6894
+	uint32_t		xdc;					// 0xdc, 6898
+	uint32_t		xe0;					// 0xe0, 689c
+	uint32_t		xe4;					// 0xe4, 68a0
+	uint32_t		xe8;					// 0xe8, 68a4
+	uint32_t		xec;					// 0xec, 68a8
+	uint32_t		xf0;					// 0xf0, 68ac
+	int32_t			another_def_q_scale;	// 0xf4, 68b0
+	int32_t			IniQScale;				// 0xf8, 68b4
+	int32_t			actual_qscale_maybe;	// 0xfc, 68b8
+	uint32_t		x100;	// 0x100, 68bc
+	uint32_t		x104;	// 0x104, 68c0
+	uint32_t		x108;	// 0x108, 68c4
+	uint32_t		x10c;	// 0x10c, 68c8
+	uint32_t		x110;	// 0x110, 68cc
+	uint32_t		x114;			// 0x114, 68d0
+	uint32_t		x118;			// 0x118, 68d4
+	uint32_t		x11c;			// 0x11c, 68d8
+	uint32_t		x120;			// 0x120, 68dc
+	uint32_t		x124;			// 0x124, 68e0
+	uint32_t		fullhd_30fps_gop_opt_0;	// 0x128, 63b8 OK
+	uint32_t		fullhd_30fps_gop_opt_1;	// 0x12c
+	uint32_t		fullhd_30fps_gop_opt_2;	// 0x130
+	uint32_t		fullhd_30fps_gop_opt_3;	// 0x134
+	uint32_t		fullhd_30fps_gop_opt_4;	// 0x138
+	uint32_t		fullhd_25fps_gop_opt_0;	// 0x13c OK
+	uint32_t		fullhd_25fps_gop_opt_1;	// 0x140
+	uint32_t		fullhd_25fps_gop_opt_2;	// 0x144
+	uint32_t		fullhd_25fps_gop_opt_3;	// 0x148
+	uint32_t		fullhd_25fps_gop_opt_4;	// 0x14c
+	uint32_t		fullhd_24fps_gop_opt_0;	// 0x150 OK
+	uint32_t		fullhd_24fps_gop_opt_1;	// 0x154
+	uint32_t		fullhd_24fps_gop_opt_2;	// 0x158
+	uint32_t		fullhd_24fps_gop_opt_3;	// 0x15c
+	uint32_t		fullhd_24fps_gop_opt_4;	// 0x160
+	uint32_t		hd_60fps_gop_opt_0;		// 0x164, 63f4 OK
+	uint32_t		hd_60fps_gop_opt_1;		// 0x168
+	uint32_t		hd_60fps_gop_opt_2;		// 0x16c
+	uint32_t		hd_60fps_gop_opt_3;		// 0x170
+	uint32_t		hd_60fps_gop_opt_4;		// 0x174
+	uint32_t		hd_50fps_gop_opt_0;		// 0x178 OK
+	uint32_t		hd_50fps_gop_opt_1;		// 0x17c
+	uint32_t		hd_50fps_gop_opt_2;		// 0x180
+	uint32_t		hd_50fps_gop_opt_3;		// 0x184
+	uint32_t		hd_50fps_gop_opt_4;		// 0x188
+	uint32_t		unk_xfps_gop_opt_0;		// 0x18c // ??
+	uint32_t		unk_xfps_gop_opt_1;		// 0x190
+	uint32_t		unk_xfps_gop_opt_2;		// 0x194
+	uint32_t		unk_xfps_gop_opt_3;		// 0x198
+	uint32_t		unk_xfps_gop_opt_4;		// 0x19c
+	uint32_t		unk_yfps_gop_opt_0;		// 0x1a0 // ??
+	uint32_t		unk_yfps_gop_opt_1;		// 0x1a4
+	uint32_t		unk_yfps_gop_opt_2;		// 0x1a8
+	uint32_t		unk_yfps_gop_opt_3;		// 0x1ac
+	uint32_t		unk_yfps_gop_opt_4;		// 0x1b0
+	uint32_t		vga_60fps_gop_opt_0;	// 0x1b4, 6444 // that's first VGA
+	uint32_t		vga_60fps_gop_opt_1;	// 0x1b8
+	uint32_t		vga_60fps_gop_opt_2;	// 0x1bc
+	uint32_t		vga_60fps_gop_opt_3;	// 0x1c0
+	uint32_t		vga_60fps_gop_opt_4;	// 0x1c4
+	uint32_t		vga_50fps_gop_opt_0;	// 0x1c8 OK
+	uint32_t		vga_50fps_gop_opt_1;	// 0x1cc
+	uint32_t		vga_50fps_gop_opt_2;	// 0x1d0
+	uint32_t		vga_50fps_gop_opt_3;	// 0x1d4
+	uint32_t		vga_50fps_gop_opt_4;	// 0x1d8
+}__attribute__((aligned,packed));
+
+//~ SIZE_CHECK_STRUCT( mvr_config, 0x30 );
+
+#endif /* __PLATFORM_MVR_H__ */

--- a/platform/1500D.130/include/platform/state-object.h
+++ b/platform/1500D.130/include/platform/state-object.h
@@ -1,0 +1,13 @@
+#ifndef __platform_state_object_h
+#define __platform_state_object_h
+
+#define DISPLAY_STATE DISPLAY_STATEOBJ
+#define INPUT_ENABLE_IMAGE_PHYSICAL_SCREEN_PARAMETER 20
+#define EVF_STATE (*(struct state_object **)0x37890)
+#define MOVREC_STATE (*(struct state_object **)0x386b0)
+
+
+
+
+
+#endif // __platform_state_object_h

--- a/platform/1500D.130/internals.h
+++ b/platform/1500D.130/internals.h
@@ -1,0 +1,6 @@
+/**
+ * Camera internals for 1500D 1.3.0
+ */
+#define CONFIG_1300D       // <--- KITA PINJAM KTP KAKAKNYA YANG SUDAH LENGKAP!
+#define CONFIG_DIGIC_IV
+#define CONFIG_HELLO_WORLD

--- a/platform/1500D.130/stubs.S
+++ b/platform/1500D.130/stubs.S
@@ -1,0 +1,41 @@
+/** \file
+ * Entry points into the firmware image.
+ *
+ * These are the functions that we can call from our tasks
+ * in the Canon 1.1.0 firmware for the 2000D
+ *
+ */
+/*
+ * Copyright (C) 2021 Magic Lantern Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the
+ * Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#include <stub.h>
+
+#include <stub.h>
+
+/** Startup / Cache Hack Booting **/
+NSTUB(ROMBASEADDR, firmware_entry)  // 0xFE0C0000
+NSTUB(0xfe0c3a38, cstart)           
+NSTUB(0x29898, bzero32)             
+NSTUB(0x5254, create_init_task)     
+NSTUB(0xFE129718, init_task)        // Temuan akuratmu di FW 1.3.0!
+NSTUB(0x3780, msleep)               
+
+/** Fungsi Layar & GUI (Untuk Clean HDMI nanti) **/
+NSTUB(0xFF18C8B4, GUI_Control)      // Temuanmu sebelumnya

--- a/platform/Makefile
+++ b/platform/Makefile
@@ -71,6 +71,7 @@ CAM_MODULES_DIR = $(BUILD_DIR)/modules
 ML_CAMS = \
     100D.101 \
     1100D.105 \
+    1500D.130 \
     200D.101 \
     500D.111 \
     50D.109 \

--- a/src/console.c
+++ b/src/console.c
@@ -9,6 +9,7 @@
 #include "zebra.h"
 #include "shoot.h"
 #include "alloca.h"
+#include "tasks.h"
 
 #ifndef CONFIG_CONSOLE
 #error Something went wrong CONFIg_CONSOLE should be defined

--- a/src/fw-signature.h
+++ b/src/fw-signature.h
@@ -8,6 +8,7 @@
 
 #define SIG_100D_101 0x3b82b55e // from FF0C0000
 #define SIG_1100D_105 0x46de7624 // from FF010000
+#define SIG_1500D_130 0xea000001 // from FE0C0000
 #define SIG_200D_101 0xf72c729a // from E0040000
 //#define SIG_500D_110 0x4c0e5a7e // from FF010000
 #define SIG_500D_111 0x44f49aef // from FF010000


### PR DESCRIPTION
Hi @reticulatedpines / @ccritix

I'm working on early porting for the 1500D (FW 1.3.0) based on the Cache Hack implementation from PR #40 (minimal/hello-world).

I have successfully found my firmware signature (`0xea000001` at `0xFE0C0000`) and set up my `Makefile` with `ROMBASEADDR = 0xFE0C0000` and `ML_BOOT_OBJ = boot-d45-ch.o`.

However, when compiling with `ML_SRC_PROFILE = minimal`, the build process stops at:
`../../src/console.c:326:39: error: invalid use of undefined type 'struct task'`

Things I've already tried in my `internals.h`:
* Added `#define CONFIG_2000D`
* Added `#define CONFIG_1300D`
* Added `#define CONFIG_DRYOS_V2_3`
* Disabled features in `features.h` (`#undef CONFIG_CRASH_LOG`, etc.)

None of these bypassed the `struct task` error in `console.c`. 

Is there a specific dummy header or flag I am missing to silence the task struct check for the `minimal` profile? Any clues or help analyzing this would be greatly appreciated. Thanks!