### PR TITLE
R: fix capture "saving" hang via CameraConductor remote-release path

### DIFF
--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -364,6 +364,10 @@ DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewA
 // THUMB_FN(0x,  SetEDmac)
 // THUMB_FN(0x,  StartEDmac)
 
+/* CameraConductor remote-release event (1=press/SW2-on, 0=release); used for a
+ * cleanly-finalized programmatic capture (see lens_take_picture). */
+THUMB_FN(0xE0190214,  SetEventIrRemoteReleaseBtn)
+
 /*
  * Stubs needed only for experiments in test_features.c
  * Do not port to other models unless you want to.

--- a/src/dryos.h
+++ b/src/dryos.h
@@ -362,6 +362,12 @@ void Gui_SetSoundRecord( int );
 void GUI_SetLvMode( int );
 #endif
 
+#ifdef CONFIG_R
+/* CameraConductor remote-release event (wireless-remote / shutter path);
+ * used by lens_take_picture for a cleanly-finalized capture. 1=press, 0=release. */
+void SetEventIrRemoteReleaseBtn(int swst);
+#endif
+
 int SoundDevActiveIn( uint32_t );
 
 #endif

--- a/src/lens.c
+++ b/src/lens.c
@@ -1090,6 +1090,15 @@ lens_take_picture(
     call("rssRelease");
     #elif defined(CONFIG_40D)
     call("FA_Release");
+    #elif defined(CONFIG_R)
+    /* On the EOS R, call("Release") issues the capture but leaves the shooting
+     * job unfinalized, so the camera hangs on "saving..." at power-off. Driving
+     * the CameraConductor remote-release path (the same one a wireless remote /
+     * the physical shutter uses) finalizes the job cleanly. 1 = press (SW2-on),
+     * 0 = release. Verified on hardware: captures and powers off clean. */
+    SetEventIrRemoteReleaseBtn(1);
+    msleep(300);
+    SetEventIrRemoteReleaseBtn(0);
     #else
     call("Release");
     #endif


### PR DESCRIPTION
## What

On the EOS R, ML's programmatic capture (`lens_take_picture` → `call("Release")`)
takes the picture but leaves the shooting job unfinalized, so the camera hangs on
**"saving..." at power-off**. The physical shutter is unaffected.

This drives the CameraConductor remote-release event (`SetEventIrRemoteReleaseBtn`)
instead — the same path a wireless remote / the physical shutter uses — which
finalizes the job cleanly. `1` = press (SW2-on), `0` = release.

## Changes
- `platform/R.180/stubs.S` — add `SetEventIrRemoteReleaseBtn` (`0xE0190214`)
- `src/dryos.h` — prototype, guarded by `CONFIG_R`
- `src/lens.c` — `#elif defined(CONFIG_R)` branch in `lens_take_picture`

This mirrors the existing per-camera release variants already in that function
(`PtpDps_remote_release_SW1_SW2_worker` for 5D2, `rssRelease` for 5DC,
`FA_Release` for 40D).

## Testing (EOS R, firmware 1.8.0, on hardware)
- Capture through the standard `take_a_pic` path now takes a photo **and powers off
  cleanly** — no "saving" hang.
- The breadcrumb trail completes through `job_state set (exposure started)`; the
  proper CC path also sets `job_state`, which `call("Release")` did not.
- Capture uses `AF_DONT_CHANGE` (MF / pre-focused). ML-driven AF on the R is a
  separate matter (`CONFIG_IMAGE_CAPTURE_NOT_WORKING`) and out of scope here.

## Notes
`SetEventIrRemoteReleaseBtn` posts the remote-release event into the normal
CameraConductor SW1/SW2 pipeline (RE'd from ROM0). Builds clean for R.180.
