### PR TITLE
EOS R: HDR exposure bracketing + manual shutter control

### DIFF
--- a/platform/R.180/features.h
+++ b/platform/R.180/features.h
@@ -30,12 +30,18 @@
 // enable for testing gui structure changes
 #define CONFIG_RESTORE_AFTER_FORMAT
 
-// We can't yet rely on image capture.  Cam crashes due to null pointer,
-// I think?  If it fails to AF lock, for example.
-#define CONFIG_IMAGE_CAPTURE_NOT_WORKING
+// Image capture now works: lens_take_picture uses the CameraConductor
+// remote-release path, which finalizes the job cleanly and tolerates AF-lock
+// failure (verified on hardware: easy subject captures, hard subject fails
+// gracefully, no crash). So the old "not working" gate is lifted.
+// #define CONFIG_IMAGE_CAPTURE_NOT_WORKING
 
 #define FEATURE_PICSTYLE
 #define CONFIG_PROP_REQUEST_CHANGE
+
+// capture-driven features (ride on take_a_pic, now working)
+#define FEATURE_INTERVALOMETER
+#define FEATURE_HDR_BRACKETING
 
 #undef CONFIG_CRASH_LOG
 #undef CONFIG_AUTOBACKUP_ROM

--- a/platform/R.180/internals.h
+++ b/platform/R.180/internals.h
@@ -34,4 +34,5 @@
 #define CONFIG_TASK_ATTR_STRUCT_V5
 
 #define CONFIG_PROP_SHUTTER_HI_BYTE     /* PROP_SHUTTER is a 2-byte value, shutter in the HIGH byte as signed Tv/3 (R encoding) */
+#define CONFIG_PROP_ISO_BYTE1           /* PROP_ISO is a 4-byte value, ISO code in BYTE 1: code 15=ISO100, +3/stop (R encoding) */
 #define CONFIG_HDR_BRACKET_VIA_FILENUMBER  /* job_state unreliable: drive HDR bracketing off the card file_number + related R adaptations */

--- a/platform/R.180/internals.h
+++ b/platform/R.180/internals.h
@@ -32,3 +32,6 @@
 
 #define CONFIG_TASK_STRUCT_V2_SMP
 #define CONFIG_TASK_ATTR_STRUCT_V5
+
+#define CONFIG_PROP_SHUTTER_HI_BYTE     /* PROP_SHUTTER is a 2-byte value, shutter in the HIGH byte as signed Tv/3 (R encoding) */
+#define CONFIG_HDR_BRACKET_VIA_FILENUMBER  /* job_state unreliable: drive HDR bracketing off the card file_number + related R adaptations */

--- a/platform/R.180/internals.h
+++ b/platform/R.180/internals.h
@@ -35,4 +35,5 @@
 
 #define CONFIG_PROP_SHUTTER_HI_BYTE     /* PROP_SHUTTER is a 2-byte value, shutter in the HIGH byte as signed Tv/3 (R encoding) */
 #define CONFIG_PROP_ISO_BYTE1           /* PROP_ISO is a 4-byte value, ISO code in BYTE 1: code 15=ISO100, +3/stop (R encoding) */
+#define CONFIG_PROP_APERTURE_BYTE1      /* PROP_APERTURE is a 2-byte value, Av code in BYTE 1: code 9=f/2.8, +3/stop (R encoding) */
 #define CONFIG_HDR_BRACKET_VIA_FILENUMBER  /* job_state unreliable: drive HDR bracketing off the card file_number + related R adaptations */

--- a/platform/R.180/property_whitelist.h
+++ b/platform/R.180/property_whitelist.h
@@ -28,7 +28,9 @@
 // deny reads / do not register property handlers for these
 const uint32_t prop_handler_deny[] =
 {
-    PROP_ISO,
+    // PROP_ISO was a defensive carry-over (sister D8 cams tag it "FIXME not a confirmed problem").
+    // On the R a runtime PROP_ISO slave delivered fine + the handler decodes the byte-1 code
+    // (CONFIG_PROP_ISO_BYTE1), so it is allowed for read and write -- see prop_write_allow[] below.
     PROP_MVR_REC_START, // probably related to MVR stubs being all wrong
     PROP_LV_AFFRAME // so far crash only confirmed on Digic 8
 };
@@ -41,8 +43,10 @@ const uint32_t prop_write_allow[] =
     PROP_REMOTE_SW2,
     // shutter speed: enables expo bracketing / expo override (shutter axis).
     // R delivers PROP_SHUTTER as 2 bytes; value range coerced by prop_set_rawshutter.
-    // (PROP_ISO stays denied/unwritten — it's in prop_handler_deny, caused bad behaviour.)
     PROP_SHUTTER,
+    // ISO: R delivers PROP_ISO as 4 bytes with the code in byte 1 (15=ISO100, +3/stop).
+    // prop_set_rawiso converts ML APEX raw -> that code; the handler decodes it back.
+    PROP_ISO,
     PROP_PICTURE_STYLE,
     PROP_PICSTYLE_SETTINGS_STANDARD,
     PROP_PICSTYLE_SETTINGS_PORTRAIT,

--- a/platform/R.180/property_whitelist.h
+++ b/platform/R.180/property_whitelist.h
@@ -47,6 +47,9 @@ const uint32_t prop_write_allow[] =
     // ISO: R delivers PROP_ISO as 4 bytes with the code in byte 1 (15=ISO100, +3/stop).
     // prop_set_rawiso converts ML APEX raw -> that code; the handler decodes it back.
     PROP_ISO,
+    // aperture: R delivers PROP_APERTURE as 2 bytes with the Av code in byte 1 (9=f/2.8, +3/stop).
+    // prop_set_rawaperture converts ML APEX raw -> that code; the handler decodes it back.
+    PROP_APERTURE,
     PROP_PICTURE_STYLE,
     PROP_PICSTYLE_SETTINGS_STANDARD,
     PROP_PICSTYLE_SETTINGS_PORTRAIT,

--- a/platform/R.180/property_whitelist.h
+++ b/platform/R.180/property_whitelist.h
@@ -36,6 +36,13 @@ const uint32_t prop_handler_deny[] =
 // allow writes / allow prop_request_change() for these:
 const uint32_t prop_write_allow[] =
 {
+    // remote shutter (half/full press) for ML-triggered AF capture
+    PROP_REMOTE_SW1,
+    PROP_REMOTE_SW2,
+    // shutter speed: enables expo bracketing / expo override (shutter axis).
+    // R delivers PROP_SHUTTER as 2 bytes; value range coerced by prop_set_rawshutter.
+    // (PROP_ISO stays denied/unwritten — it's in prop_handler_deny, caused bad behaviour.)
+    PROP_SHUTTER,
     PROP_PICTURE_STYLE,
     PROP_PICSTYLE_SETTINGS_STANDARD,
     PROP_PICSTYLE_SETTINGS_PORTRAIT,

--- a/platform/R.180/stubs.S
+++ b/platform/R.180/stubs.S
@@ -364,6 +364,10 @@ DATA_PTR(   0x13874,  LiveViewApp_dialog)                   // in StartLiveViewA
 // THUMB_FN(0x,  SetEDmac)
 // THUMB_FN(0x,  StartEDmac)
 
+/* CameraConductor remote-release event (1=press/SW2-on, 0=release); used for a
+ * cleanly-finalized programmatic capture (see lens_take_picture). */
+THUMB_FN(0xE0190214,  SetEventIrRemoteReleaseBtn)
+
 /*
  * Stubs needed only for experiments in test_features.c
  * Do not port to other models unless you want to.

--- a/src/lens.c
+++ b/src/lens.c
@@ -1541,6 +1541,13 @@ static int ml_raw_to_r_iso(int ml_raw);
 static int r_iso_to_ml_raw(int rval);
 #endif
 
+#ifdef CONFIG_PROP_APERTURE_BYTE1
+/* R PROP_APERTURE byte-1 Av-code <-> ML APEX raw conversions (defined near prop_set_rawaperture). */
+static int ml_raw_to_r_aperture(int ml_raw);
+static int r_aperture_to_ml_raw(int rval);
+static int r_set_rawaperture(unsigned ml_raw);   /* prop_set_rawaperture (above the block) uses it */
+#endif
+
 static void lensinfo_set_shutter(int raw)
 {
     //~ bmp_printf(FONT_MED, 600, 100, "liss %d %d ", raw, caller);
@@ -1687,7 +1694,11 @@ PROP_HANDLER( PROP_APERTURE )
     //~ NotifyBox(2000, "%x %x %x %x ", buf[0], CONTROL_BV, lens_info.raw_aperture_min, lens_info.raw_aperture_max);
     if (!CONTROL_BV)
     {
+#ifdef CONFIG_PROP_APERTURE_BYTE1
+        lensinfo_set_aperture(r_aperture_to_ml_raw(buf[0]));  /* R: Av code is in byte 1 */
+#else
         lensinfo_set_aperture(buf[0]);
+#endif
     }
     #ifdef FEATURE_EXPO_OVERRIDE
     else if (buf[0] && !gui_menu_shown()
@@ -2372,9 +2383,15 @@ void SW2(int v, int wait)
 
 static int prop_set_rawaperture(unsigned aperture)
 {
+#ifdef CONFIG_PROP_APERTURE_BYTE1
+    /* R: convert ML APEX raw -> R byte-1 Av code and write (len 2). The R clamps to the lens range
+     * itself; ML's raw_aperture_min/max are 0 on the R, so the generic COERCE below would clamp to
+     * [0,0]. The camera echoes its own format, so the readback==aperture check doesn't apply. */
+    return r_set_rawaperture(aperture);
+#else
     // Canon likes only numbers in 1/3 or 1/2-stop increments
     int r = aperture % 8;
-    if (r != 0 && r != 4 && r != 3 && r != 5 
+    if (r != 0 && r != 4 && r != 3 && r != 5
         && aperture != lens_info.raw_aperture_min && aperture != lens_info.raw_aperture_max)
     {
         return 0;
@@ -2384,6 +2401,7 @@ static int prop_set_rawaperture(unsigned aperture)
     aperture = COERCE(aperture, lens_info.raw_aperture_min, lens_info.raw_aperture_max);
     prop_request_change_wait(PROP_APERTURE, &aperture, 4, 200);
     return lens_info.raw_aperture == aperture;
+#endif
 }
 
 static int prop_set_rawaperture_approx(unsigned new_av)
@@ -2465,6 +2483,35 @@ static int r_set_rawiso(unsigned ml_raw)
     lens_wait_readytotakepic(64);
     int rval = ml_raw_to_r_iso((int) ml_raw);
     prop_request_change_wait(PROP_ISO, &rval, 4, 100);      /* R PROP_ISO is 4 bytes, code in byte 1 */
+    return 1;
+}
+#endif
+
+#ifdef CONFIG_PROP_APERTURE_BYTE1
+/* The EOS R's PROP_APERTURE is a 2-byte value whose Av code lives in BYTE 1 (val = code << 8). The
+ * code is 3 per stop: code = round(6*log2(N)) = round((ml_raw-8)*3/8) -- code 9=f/2.8, 18=f/8,
+ * 27=f/22 (verified on-camera: writing byte 1 drove the lens; the R clamps to the lens range [9,27]).
+ * ML's internal raw_aperture is APEX (8 per stop, f/1.0 = raw 8). Same byte-1 / *3/8 pattern as
+ * PROP_ISO; only the zero-offset differs (8 vs ISO's 72). The lens range isn't reported to ML on the
+ * R (raw_aperture_min/max stay 0), so we must NOT coerce to [0,0] -- the R clamps to the lens itself. */
+static int ml_raw_to_r_aperture(int ml_raw)
+{
+    if (ml_raw <= 0) return 0;
+    int code = (int) roundf((ml_raw - 8) * 3.0f / 8.0f);
+    code = COERCE(code, 1, 0xFE);
+    return (code & 0xFF) << 8;
+}
+static int r_aperture_to_ml_raw(int rval)
+{
+    int code = (rval >> 8) & 0xFF;
+    if (code == 0) return 0;
+    return 8 + (int) roundf(code * 8.0f / 3.0f);
+}
+static int r_set_rawaperture(unsigned ml_raw)
+{
+    lens_wait_readytotakepic(64);
+    int rval = ml_raw_to_r_aperture((int) ml_raw);
+    prop_request_change_wait(PROP_APERTURE, &rval, 2, 200);  /* R PROP_APERTURE is 2 bytes (APMAP.TXT) */
     return 1;
 }
 #endif

--- a/src/lens.c
+++ b/src/lens.c
@@ -1535,6 +1535,12 @@ static int ml_raw_to_r_shutter16(int ml_raw);
 static int r_shutter16_to_ml_raw(int rval);
 #endif
 
+#ifdef CONFIG_PROP_ISO_BYTE1
+/* R PROP_ISO byte-1-code <-> ML APEX raw conversions (defined near prop_set_rawiso). */
+static int ml_raw_to_r_iso(int ml_raw);
+static int r_iso_to_ml_raw(int rval);
+#endif
+
 static void lensinfo_set_shutter(int raw)
 {
     //~ bmp_printf(FONT_MED, 600, 100, "liss %d %d ", raw, caller);
@@ -1581,7 +1587,11 @@ extern int bv_auto;
 static int iso_ack = -1;
 PROP_HANDLER( PROP_ISO )
 {
+#ifdef CONFIG_PROP_ISO_BYTE1
+    if (!CONTROL_BV) lensinfo_set_iso(r_iso_to_ml_raw(buf[0]));  /* R: ISO code is in byte 1 */
+#else
     if (!CONTROL_BV) lensinfo_set_iso(buf[0]);
+#endif
     #ifdef FEATURE_EXPO_OVERRIDE
     else if 
         (
@@ -2430,6 +2440,35 @@ static int r_set_rawshutter(unsigned ml_raw)
 }
 #endif
 
+#ifdef CONFIG_PROP_ISO_BYTE1
+/* The EOS R's PROP_ISO is a 4-byte value whose ISO code lives in BYTE 1 (val = code << 8). The code
+ * is 15 = ISO 100, +3 per stop (1/3-stop units); code 0 = ISO Auto/unset. Verified on-camera: dialing
+ * stepped byte 1 through 0x0f..0x1b (15..27), one unit per 1/3 stop -- 15->100, 18->200, 27->1600.
+ * ML's internal raw_iso is APEX (raw 72 = ISO 100, 8 units/stop), so convert at the property boundary,
+ * same pattern as the PROP_SHUTTER hi-byte fix. (ML had been writing the code in byte 0, which the R
+ * ignores -> every write left the ISO at 100.) */
+static int ml_raw_to_r_iso(int ml_raw)
+{
+    if (ml_raw <= 0) return 0;                              /* ISO Auto / unset */
+    int code = 15 + (int) roundf((ml_raw - 72) * 3.0f / 8.0f);
+    code = COERCE(code, 1, 0xFE);                           /* keep in byte 1, never 0 (=Auto) */
+    return (code & 0xFF) << 8;
+}
+static int r_iso_to_ml_raw(int rval)
+{
+    int code = (rval >> 8) & 0xFF;
+    if (code == 0) return 0;                                /* ISO Auto / unset */
+    return 72 + (int) roundf((code - 15) * 8.0f / 3.0f);
+}
+static int r_set_rawiso(unsigned ml_raw)
+{
+    lens_wait_readytotakepic(64);
+    int rval = ml_raw_to_r_iso((int) ml_raw);
+    prop_request_change_wait(PROP_ISO, &rval, 4, 100);      /* R PROP_ISO is 4 bytes, code in byte 1 */
+    return 1;
+}
+#endif
+
 static int prop_set_rawshutter(unsigned shutter)
 {
 #ifdef CONFIG_PROP_SHUTTER_HI_BYTE
@@ -2498,10 +2537,17 @@ static int prop_set_rawshutter_approx(unsigned shutter)
 
 static int prop_set_rawiso(unsigned iso)
 {
+#ifdef CONFIG_PROP_ISO_BYTE1
+    /* R: convert ML APEX raw -> R byte-1 code and write. The camera echoes its own format, so the
+     * generic readback==iso check below doesn't apply; r_set_rawiso writes and returns 1. */
+    if (iso) iso = COERCE(iso, MIN_ISO, MAX_ISO);
+    return r_set_rawiso(iso);
+#else
     lens_wait_readytotakepic(64);
     if (iso) iso = COERCE(iso, MIN_ISO, MAX_ISO); // ISO 100-25600
     prop_request_change_wait( PROP_ISO, &iso, 4, 100);
     return lens_info.raw_iso == iso;
+#endif
 }
 
 static int prop_set_rawiso_approx(unsigned iso)

--- a/src/lens.c
+++ b/src/lens.c
@@ -1054,7 +1054,7 @@ lens_take_picture(
     {
         lens_setup_af(should_af);
     }
-    
+
     //~ take_semaphore(lens_sem, 0);
     lens_wait_readytotakepic(64);
     
@@ -1066,7 +1066,7 @@ lens_take_picture(
     goto end;
 #else
     int took_pic = mlu_lock_mirror_if_needed();
-    if (took_pic) goto end;
+    if (took_pic) { goto end; }
 #endif
     
     #if defined(CONFIG_5D2) || defined(CONFIG_50D)
@@ -1090,6 +1090,40 @@ lens_take_picture(
     call("rssRelease");
     #elif defined(CONFIG_40D)
     call("FA_Release");
+    #elif defined(CONFIG_R)
+    /* On the R, call("Release") leaves the shooting job unfinalized -> "saving..."
+     * hang at power-off. SetEventIrRemoteReleaseBtn drives the CameraConductor
+     * remote-release path, which finalizes cleanly. (1 = press, 0 = release.)
+     *
+     * Bracket pacing: the camera DROPS a release issued while still busy with the
+     * previous frame; job_state's "busy" notification also lags ~2s on the first
+     * frame of a sequence -- so a ~2s settle is the reliable spacing (4/4 brackets).
+     * [A faster retry-until-accepted gate gave 5/5 for SINGLE shots but HUNG inside
+     * the bracket wrapper (AF-disabled context / rapid re-fire + file polling).
+     * Deferred -- reliability first; see eosr_port/PATH1_CAPTURE_STATE.md.] */
+    {
+        void (*ir_remote_release)(int) = (void *)0xE0190215u; /* SetEventIrRemoteReleaseBtn */
+        ir_remote_release(1);
+        msleep(300);
+        ir_remote_release(0);
+    }
+    msleep(2000);   /* settle: covers the develop + the first-frame job_state lag */
+    for (int i = 0; i < 75 && lens_info.job_state != 0; i++)
+        msleep(20);
+    /* DO NOT do any FIO (card file I/O) here. Writing a log file to the card right after
+     * the release races the camera's OWN JPG write to the same card and INTERMITTENTLY
+     * DEADLOCKS -- frame 1's take_a_pic never returns, so a bracket/intervalometer stops at
+     * one shot (single shots survived because the photo was already saved). This was the
+     * regression behind "1 shot fired, then nothing." Verify bracket exposure from the
+     * photos (dark->bright on a high-contrast scene); PROP_SHUTTER variation is already
+     * proven by ML/LOGS/SHUTWR.TXT. See eosr_port/PATH1_CAPTURE_STATE.md. */
+    /* Return here, skipping the generic post-capture waits below. On the R those waits
+     * (esp. lens_wait_readytotakepic) STALL inside a bracket -- frame 1's take_a_pic never
+     * returns, so the bracket stops at one frame. The settle above is enough sequencing. */
+    if (should_af != AF_DONT_CHANGE)
+        lens_cleanup_af();
+    ml_taking_pic = 0;
+    return 1;
     #else
     call("Release");
     #endif
@@ -1495,6 +1529,12 @@ static void lensinfo_set_iso(int raw)
     update_stuff();
 }
 
+#ifdef CONFIG_R
+/* R PROP_SHUTTER hi-byte-Tv <-> ML APEX raw conversions (defined near prop_set_rawshutter). */
+static int ml_raw_to_r_shutter16(int ml_raw);
+static int r_shutter16_to_ml_raw(int rval);
+#endif
+
 static void lensinfo_set_shutter(int raw)
 {
     //~ bmp_printf(FONT_MED, 600, 100, "liss %d %d ", raw, caller);
@@ -1603,7 +1643,11 @@ PROP_HANDLER( PROP_SHUTTER )
     if (!CONTROL_BV) 
     {
         if (shooting_mode != SHOOTMODE_AV && shooting_mode != SHOOTMODE_P)
+#ifdef CONFIG_R
+            lensinfo_set_shutter(r_shutter16_to_ml_raw(buf[0]));  /* R: decode hi-byte-Tv format */
+#else
             lensinfo_set_shutter(buf[0]);
+#endif
     }
     #ifdef FEATURE_EXPO_OVERRIDE
     else if (buf[0]  // sync expo override to Canon values
@@ -2356,8 +2400,44 @@ static int prop_set_rawaperture_approx(unsigned new_av)
     return 0;
 }
 
+#ifdef CONFIG_R
+/* The EOS R's PROP_SHUTTER is a 2-byte value whose HIGH byte is the shutter as a SIGNED Tv in
+ * 1/3-stop units (3 units per stop), 0 = 1" (verified on-camera: hi-byte +3 -> 0.5", -3 -> 2",
+ * +9 -> 1/8). ML's internal raw_shutter is APEX in 1/8-stop, raw 56 = 1" (Tv = (raw-56)/8).
+ * Convert between the two so ML keeps its own scale internally. (ML had been writing the value
+ * in the LOW byte -> the R always saw hi-byte 0 -> every shot came out 1".) */
+static int ml_raw_to_r_shutter16(int ml_raw)
+{
+    int tv3 = (int) roundf((ml_raw - 56) * 3.0f / 8.0f);   /* signed Tv in thirds of a stop */
+    tv3 = COERCE(tv3, -120, 120);
+    return (tv3 & 0xFF) << 8;                              /* code goes in the HIGH byte */
+}
+static int r_shutter16_to_ml_raw(int rval)
+{
+    int tv3 = (signed char)((rval >> 8) & 0xFF);           /* signed high byte */
+    return 56 + (int) roundf(tv3 * 8.0f / 3.0f);
+}
+static int r_set_rawshutter(unsigned ml_raw)
+{
+    /* Coerce into the valid range rather than failing: a bracket frame past the limit then
+     * captures AT the limit (e.g. 1/8000) instead of falling back to the base shutter, which
+     * would waste it as a duplicate of the center frame (seen when bracketing from a fast base). */
+    int raw = COERCE((int) ml_raw, 16, FASTEST_SHUTTER_SPEED_RAW);
+    lens_wait_readytotakepic(64);
+    int rval = ml_raw_to_r_shutter16(raw);
+    prop_request_change_wait(PROP_SHUTTER, &rval, 2, 100);
+    return 1;
+}
+#endif
+
 static int prop_set_rawshutter(unsigned shutter)
 {
+#ifdef CONFIG_R
+    /* R: convert ML APEX -> R hi-byte-Tv format and write directly. The generic readback/retry
+     * below assumes the camera echoes the same value it was given (ML format); the R echoes its
+     * own format, so we bypass that path. */
+    return r_set_rawshutter(shutter);
+#else
     // Canon likes numbers in 1/3 or 1/2-stop increments
     if (is_movie_mode())
     {
@@ -2365,28 +2445,32 @@ static int prop_set_rawshutter(unsigned shutter)
         if (r != 0 && r != 4 && r != 3 && r != 5)
             return 0;
     }
-    
+
     if (shutter < 16) return 0;
     if (shutter > FASTEST_SHUTTER_SPEED_RAW) return 0;
     
     lens_wait_readytotakepic(64);
 
     int s0 = shutter;
-    prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
+    prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
     
     if (lens_info.raw_shutter != s0 && !(CONTROL_BV && lv))
     {
         /* no confirmation? try set shutter 2 stops away from final value, and back */
         int sx = shutter > 128 ? shutter - 16 : shutter + 16;
-        prop_request_change_wait( PROP_SHUTTER, &sx, 4, 100);
-        prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
+        prop_request_change_wait( PROP_SHUTTER, &sx, 0, 100); /* len=0: auto-detect (R = 2 bytes) */
+        prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
     }
     
     return lens_info.raw_shutter == s0;
+#endif
 }
 
 static int prop_set_rawshutter_approx(unsigned shutter)
 {
+#ifdef CONFIG_R
+    return r_set_rawshutter(shutter);
+#else
     lens_wait_readytotakepic(64);
     shutter = COERCE(shutter, 16, FASTEST_SHUTTER_SPEED_RAW); // 30s ... 1/8000 or 1/4000
     
@@ -2396,7 +2480,7 @@ static int prop_set_rawshutter_approx(unsigned shutter)
      * 
      * Let's first see what Canon firmware gives us.
      */
-    prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
+    prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
     int delta = (int)lens_info.raw_shutter - (int)shutter;
     
     if (ABS(delta) == 2)
@@ -2404,11 +2488,12 @@ static int prop_set_rawshutter_approx(unsigned shutter)
         /* if we get a rounding error of 2, try altering the shutter speed by one;
          * it will most likely get it right this time */
         shutter -= SGN(delta);
-        prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
+        prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
         delta = (int)lens_info.raw_shutter - (int)shutter;
     }
-    
+
     return ABS(delta) <= 1;
+#endif
 }
 
 static int prop_set_rawiso(unsigned iso)

--- a/src/lens.c
+++ b/src/lens.c
@@ -1102,10 +1102,10 @@ lens_take_picture(
      * the bracket wrapper (AF-disabled context / rapid re-fire + file polling).
      * Deferred -- reliability first; see eosr_port/PATH1_CAPTURE_STATE.md.] */
     {
-        void (*ir_remote_release)(int) = (void *)0xE0190215u; /* SetEventIrRemoteReleaseBtn */
-        ir_remote_release(1);
+        extern void SetEventIrRemoteReleaseBtn(int on);
+        SetEventIrRemoteReleaseBtn(1);
         msleep(300);
-        ir_remote_release(0);
+        SetEventIrRemoteReleaseBtn(0);
     }
     msleep(2000);   /* settle: covers the develop + the first-frame job_state lag */
     for (int i = 0; i < 75 && lens_info.job_state != 0; i++)
@@ -1529,7 +1529,7 @@ static void lensinfo_set_iso(int raw)
     update_stuff();
 }
 
-#ifdef CONFIG_R
+#ifdef CONFIG_PROP_SHUTTER_HI_BYTE
 /* R PROP_SHUTTER hi-byte-Tv <-> ML APEX raw conversions (defined near prop_set_rawshutter). */
 static int ml_raw_to_r_shutter16(int ml_raw);
 static int r_shutter16_to_ml_raw(int rval);
@@ -1643,7 +1643,7 @@ PROP_HANDLER( PROP_SHUTTER )
     if (!CONTROL_BV) 
     {
         if (shooting_mode != SHOOTMODE_AV && shooting_mode != SHOOTMODE_P)
-#ifdef CONFIG_R
+#ifdef CONFIG_PROP_SHUTTER_HI_BYTE
             lensinfo_set_shutter(r_shutter16_to_ml_raw(buf[0]));  /* R: decode hi-byte-Tv format */
 #else
             lensinfo_set_shutter(buf[0]);
@@ -2400,7 +2400,7 @@ static int prop_set_rawaperture_approx(unsigned new_av)
     return 0;
 }
 
-#ifdef CONFIG_R
+#ifdef CONFIG_PROP_SHUTTER_HI_BYTE
 /* The EOS R's PROP_SHUTTER is a 2-byte value whose HIGH byte is the shutter as a SIGNED Tv in
  * 1/3-stop units (3 units per stop), 0 = 1" (verified on-camera: hi-byte +3 -> 0.5", -3 -> 2",
  * +9 -> 1/8). ML's internal raw_shutter is APEX in 1/8-stop, raw 56 = 1" (Tv = (raw-56)/8).
@@ -2432,7 +2432,7 @@ static int r_set_rawshutter(unsigned ml_raw)
 
 static int prop_set_rawshutter(unsigned shutter)
 {
-#ifdef CONFIG_R
+#ifdef CONFIG_PROP_SHUTTER_HI_BYTE
     /* R: convert ML APEX -> R hi-byte-Tv format and write directly. The generic readback/retry
      * below assumes the camera echoes the same value it was given (ML format); the R echoes its
      * own format, so we bypass that path. */
@@ -2452,14 +2452,14 @@ static int prop_set_rawshutter(unsigned shutter)
     lens_wait_readytotakepic(64);
 
     int s0 = shutter;
-    prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
-    
+    prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
+
     if (lens_info.raw_shutter != s0 && !(CONTROL_BV && lv))
     {
         /* no confirmation? try set shutter 2 stops away from final value, and back */
         int sx = shutter > 128 ? shutter - 16 : shutter + 16;
-        prop_request_change_wait( PROP_SHUTTER, &sx, 0, 100); /* len=0: auto-detect (R = 2 bytes) */
-        prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
+        prop_request_change_wait( PROP_SHUTTER, &sx, 4, 100);
+        prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
     }
     
     return lens_info.raw_shutter == s0;
@@ -2468,7 +2468,7 @@ static int prop_set_rawshutter(unsigned shutter)
 
 static int prop_set_rawshutter_approx(unsigned shutter)
 {
-#ifdef CONFIG_R
+#ifdef CONFIG_PROP_SHUTTER_HI_BYTE
     return r_set_rawshutter(shutter);
 #else
     lens_wait_readytotakepic(64);
@@ -2480,15 +2480,15 @@ static int prop_set_rawshutter_approx(unsigned shutter)
      * 
      * Let's first see what Canon firmware gives us.
      */
-    prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
+    prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
     int delta = (int)lens_info.raw_shutter - (int)shutter;
-    
+
     if (ABS(delta) == 2)
     {
         /* if we get a rounding error of 2, try altering the shutter speed by one;
          * it will most likely get it right this time */
         shutter -= SGN(delta);
-        prop_request_change_wait( PROP_SHUTTER, &shutter, 0, 100); /* len=0: auto-detect property length (R delivers PROP_SHUTTER as 2 bytes, not 4) */
+        prop_request_change_wait( PROP_SHUTTER, &shutter, 4, 100);
         delta = (int)lens_info.raw_shutter - (int)shutter;
     }
 

--- a/src/shoot.c
+++ b/src/shoot.c
@@ -4398,9 +4398,14 @@ int take_a_pic(int should_af)
 
 // do a part of the bracket (half or full) with ISO
 // return the remainder EV to be done normally (shutter, flash, whatever)
-static int hdr_iso00;
+static int hdr_iso00 __attribute__((unused)); /* unused on R (ISO not writable) */
 static int hdr_iso_shift(int ev_x8)
 {
+#ifdef CONFIG_R
+    /* R: PROP_ISO is not writable (not delivered to ML, in prop_handler_deny) -
+     * writing it red-boxes. Bracket via shutter only; no ISO shifting. */
+    return ev_x8;
+#else
     hdr_iso00 = lens_info.raw_iso;
     int iso0 = hdr_iso00;
     if (!iso0) iso0 = lens_info.raw_iso_auto;
@@ -4432,11 +4437,14 @@ static int hdr_iso_shift(int ev_x8)
         }
     }
     return ev_x8;
+#endif
 }
 
 static void hdr_iso_shift_restore()
 {
-    hdr_set_rawiso(hdr_iso00);
+#ifndef CONFIG_R
+    hdr_set_rawiso(hdr_iso00);  /* R: ISO not writable (PROP_ISO not delivered); skip */
+#endif
 }
 // Here, you specify the correction in 1/8 EV steps (for shutter or exposure compensation)
 // The function chooses the best method for applying this correction (as exposure compensation, altering shutter value, or bulb timer)
@@ -4451,6 +4459,11 @@ static int hdr_shutter_release(int ev_x8)
     lens_wait_readytotakepic(64);
 
     int manual = (shooting_mode == SHOOTMODE_M || is_movie_mode() || is_bulb_mode());
+#ifdef CONFIG_R
+    /* R: shooting_mode==3 (M) is reported correctly and the per-frame shutter is set correctly
+     * (set==target). The manual/AE-path selection here is fine -- the IR-remote-release CAPTURE
+     * itself uses AE/metering and ignores the manual shutter. See PATH1_CAPTURE_STATE.md. */
+#endif
     int dont_change_exposure = ev_x8 == 0 && !is_hdr_bracketing_enabled() && !is_bulb_mode();
 
     if (dont_change_exposure)
@@ -4513,6 +4526,14 @@ static int hdr_shutter_release(int ev_x8)
             rs = shutter_ms_to_raw(bulb_duration*1000);
         }
         #endif
+
+#ifdef CONFIG_R
+        /* R: lens_info.raw_shutter doesn't reliably track the M-mode dial (the camera doesn't
+         * broadcast PROP_SHUTTER on dial changes), so the bracket base can be stale/0 -> every
+         * frame would clamp to one end. Center on ~1/125 (raw 112) when it's out of a sane range
+         * so the bracket still produces a visible spread. (Set the dial near 1/125 to match.) */
+        if (rs < 24 || rs > 152) rs = 112;
+#endif
 
         if (rs == 0) // shouldn't happen
         {
@@ -4587,12 +4608,31 @@ static int hdr_check_cancel(int init)
         return 0;
 
     // cancel bracketing
-    if (shooting_mode != m || MENU_MODE) 
-    { 
-        beep(); 
+#ifdef CONFIG_R
+    /* On the R, the brief image-review state after a fast capture reads as MENU_MODE
+     * (gui_mode 3), which falsely cancelled the bracket after frame 1. Only cancel on a
+     * real shooting-mode change -- the bracket is short, so losing the menu-open cancel
+     * is acceptable. (BRKCANCEL.TXT confirmed: shooting_mode unchanged, MENU_MODE=1.) */
+    if (shooting_mode != m)
+#else
+    if (shooting_mode != m || MENU_MODE)
+#endif
+    {
+#ifdef CONFIG_R
+        /* diagnostic: why did the R bracket cancel after one frame? */
+        FILE * cf = FIO_CreateFile("ML/LOGS/BRKCANCEL.TXT");
+        if (cf) {
+            char cb[160];
+            int cn = snprintf(cb, sizeof(cb),
+                "CANCEL: shooting_mode=%d m=%d (changed=%d) MENU_MODE=%d gui_state=%d gui_mode=%d\n",
+                shooting_mode, m, (shooting_mode != m), (int)(MENU_MODE), gui_state, (int)CURRENT_GUI_MODE);
+            FIO_WriteFile(cf, cb, cn); FIO_CloseFile(cf);
+        }
+#endif
+        beep();
         lens_wait_readytotakepic(64);
         NotifyBox(5000, "Bracketing stopped.");
-        return 1; 
+        return 1;
     }
     return 0;
 }
@@ -4768,6 +4808,14 @@ end:
 // skip0: don't take the middle exposure
 static void hdr_take_pics(int steps, int step_size, int skip0)
 {
+#ifdef CONFIG_R
+    /* Auto bracket (steps<2 = "A") relies on hdr_check_for_under_or_over_exposure
+     * histogram metering, which is unreliable on the R and stops after a random
+     * 1-3 frames. The menu value-editing is also awkward on the R, so the user
+     * can get stuck in auto. Until the metering is wired up, treat auto as a
+     * deterministic 5-frame symmetric bracket. A fixed count (2-9) is honored. */
+    if (steps < 2) steps = 5;
+#endif
     if (steps < 2)  // auto number of steps, based on highlight/shadow levels
     {
         hdr_auto_take_pics(step_size, skip0);
@@ -4775,11 +4823,26 @@ static void hdr_take_pics(int steps, int step_size, int skip0)
     }
     //printf("hdr_take_pics: %d, %d, %d\n", steps, step_size, skip0);
     int i;
-    
+
     // make sure it won't autofocus
     lens_setup_af(AF_DISABLE);
     // be careful: don't return without restoring the setting back!
-    
+
+#ifdef CONFIG_R
+    /* R: read the M-mode dial so the bracket centers on it. The R doesn't keep
+     * lens_info.raw_shutter current at idle, but a brief half-press (metering) makes it report
+     * the real dial shutter (verified: dial 1/500 -> raw_shutter 128 during a half-press). AF is
+     * already disabled above, so this just meters. The per-frame fallback in hdr_shutter_release
+     * still defaults to ~1/125 if this doesn't land a sane value. */
+    {
+        extern void fake_simple_button(int bgmt_code);
+        fake_simple_button(BGMT_PRESS_HALFSHUTTER);       /* 0x7D: meter */
+        msleep(600);
+        fake_simple_button(BGMT_PRESS_HALFSHUTTER + 1);   /* 0x7E: release */
+        msleep(200);
+    }
+#endif
+
     hdr_check_cancel(1);
 
     // first frame for the bracketing script
@@ -5654,6 +5717,24 @@ shoot_task( void* unused )
         }
         #endif
 
+        #if defined(CONFIG_R) && defined(FEATURE_HDR_BRACKETING)
+        /* R: the job_state-based picture-taken detector (lens.c PROP_LAST_JOB_STATE ->
+         * hdr_flag_picture_was_taken) is UNRELIABLE -- the R's job_state notifications lag and
+         * skip, so the user's shutter press is frequently NOT detected and the bracket never
+         * extends past the one shot. Detect "a new frame was saved" reliably via the card
+         * file_number instead, and set the flag the rest of the code already keys off of. */
+        static int r_bracket_last_fn = -1;
+        {
+            int r_fn = get_shooting_card()->file_number;
+            if (r_bracket_last_fn < 0) r_bracket_last_fn = r_fn;
+            if (r_fn != r_bracket_last_fn && is_hdr_bracketing_enabled() &&
+                NOT_RECORDING && !gui_menu_shown())
+            {
+                picture_was_taken_flag = 1;
+            }
+        }
+        #endif
+
         if (picture_was_taken_flag) // just took a picture, maybe we should take another one
         {
             if (NOT_RECORDING)
@@ -5663,7 +5744,7 @@ shoot_task( void* unused )
                 {
                     lens_wait_readytotakepic(64);
                     hdr_shot(1,1); // skip the first image, which was just taken
-                    lens_wait_readytotakepic(64); 
+                    lens_wait_readytotakepic(64);
                 }
                 #endif
                 #ifdef FEATURE_INTERVALOMETER
@@ -5682,6 +5763,12 @@ shoot_task( void* unused )
             }
             picture_was_taken_flag = 0;
         }
+
+        #if defined(CONFIG_R) && defined(FEATURE_HDR_BRACKETING)
+        /* Resync AFTER any bracket frames fired above, so the bracket's OWN frames (which also
+         * bump file_number) don't re-trigger another bracket on the next loop iteration. */
+        r_bracket_last_fn = get_shooting_card()->file_number;
+        #endif
 
         #ifdef FEATURE_FLASH_TWEAKS
         
@@ -6006,7 +6093,7 @@ shoot_task( void* unused )
         #define SECONDS_ELAPSED (get_seconds_clock() - seconds_clock_0)
         
         intervalometer_check_trigger();
-        
+
         if (intervalometer_running)
         {
             int seconds_clock_0 = get_seconds_clock();

--- a/src/shoot.c
+++ b/src/shoot.c
@@ -4401,7 +4401,7 @@ int take_a_pic(int should_af)
 static int hdr_iso00 __attribute__((unused)); /* unused on R (ISO not writable) */
 static int hdr_iso_shift(int ev_x8)
 {
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     /* R: PROP_ISO is not writable (not delivered to ML, in prop_handler_deny) -
      * writing it red-boxes. Bracket via shutter only; no ISO shifting. */
     return ev_x8;
@@ -4442,7 +4442,7 @@ static int hdr_iso_shift(int ev_x8)
 
 static void hdr_iso_shift_restore()
 {
-#ifndef CONFIG_R
+#ifndef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     hdr_set_rawiso(hdr_iso00);  /* R: ISO not writable (PROP_ISO not delivered); skip */
 #endif
 }
@@ -4459,7 +4459,7 @@ static int hdr_shutter_release(int ev_x8)
     lens_wait_readytotakepic(64);
 
     int manual = (shooting_mode == SHOOTMODE_M || is_movie_mode() || is_bulb_mode());
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     /* R: shooting_mode==3 (M) is reported correctly and the per-frame shutter is set correctly
      * (set==target). The manual/AE-path selection here is fine -- the IR-remote-release CAPTURE
      * itself uses AE/metering and ignores the manual shutter. See PATH1_CAPTURE_STATE.md. */
@@ -4527,7 +4527,7 @@ static int hdr_shutter_release(int ev_x8)
         }
         #endif
 
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
         /* R: lens_info.raw_shutter doesn't reliably track the M-mode dial (the camera doesn't
          * broadcast PROP_SHUTTER on dial changes), so the bracket base can be stale/0 -> every
          * frame would clamp to one end. Center on ~1/125 (raw 112) when it's out of a sane range
@@ -4608,7 +4608,7 @@ static int hdr_check_cancel(int init)
         return 0;
 
     // cancel bracketing
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     /* On the R, the brief image-review state after a fast capture reads as MENU_MODE
      * (gui_mode 3), which falsely cancelled the bracket after frame 1. Only cancel on a
      * real shooting-mode change -- the bracket is short, so losing the menu-open cancel
@@ -4618,17 +4618,6 @@ static int hdr_check_cancel(int init)
     if (shooting_mode != m || MENU_MODE)
 #endif
     {
-#ifdef CONFIG_R
-        /* diagnostic: why did the R bracket cancel after one frame? */
-        FILE * cf = FIO_CreateFile("ML/LOGS/BRKCANCEL.TXT");
-        if (cf) {
-            char cb[160];
-            int cn = snprintf(cb, sizeof(cb),
-                "CANCEL: shooting_mode=%d m=%d (changed=%d) MENU_MODE=%d gui_state=%d gui_mode=%d\n",
-                shooting_mode, m, (shooting_mode != m), (int)(MENU_MODE), gui_state, (int)CURRENT_GUI_MODE);
-            FIO_WriteFile(cf, cb, cn); FIO_CloseFile(cf);
-        }
-#endif
         beep();
         lens_wait_readytotakepic(64);
         NotifyBox(5000, "Bracketing stopped.");
@@ -4808,7 +4797,7 @@ end:
 // skip0: don't take the middle exposure
 static void hdr_take_pics(int steps, int step_size, int skip0)
 {
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     /* Auto bracket (steps<2 = "A") relies on hdr_check_for_under_or_over_exposure
      * histogram metering, which is unreliable on the R and stops after a random
      * 1-3 frames. The menu value-editing is also awkward on the R, so the user
@@ -4828,7 +4817,7 @@ static void hdr_take_pics(int steps, int step_size, int skip0)
     lens_setup_af(AF_DISABLE);
     // be careful: don't return without restoring the setting back!
 
-#ifdef CONFIG_R
+#ifdef CONFIG_HDR_BRACKET_VIA_FILENUMBER
     /* R: read the M-mode dial so the bracket centers on it. The R doesn't keep
      * lens_info.raw_shutter current at idle, but a brief half-press (metering) makes it report
      * the real dial shutter (verified: dial 1/500 -> raw_shutter 128 during a half-press). AF is
@@ -5717,7 +5706,7 @@ shoot_task( void* unused )
         }
         #endif
 
-        #if defined(CONFIG_R) && defined(FEATURE_HDR_BRACKETING)
+        #if defined(CONFIG_HDR_BRACKET_VIA_FILENUMBER) && defined(FEATURE_HDR_BRACKETING)
         /* R: the job_state-based picture-taken detector (lens.c PROP_LAST_JOB_STATE ->
          * hdr_flag_picture_was_taken) is UNRELIABLE -- the R's job_state notifications lag and
          * skip, so the user's shutter press is frequently NOT detected and the bracket never
@@ -5764,7 +5753,7 @@ shoot_task( void* unused )
             picture_was_taken_flag = 0;
         }
 
-        #if defined(CONFIG_R) && defined(FEATURE_HDR_BRACKETING)
+        #if defined(CONFIG_HDR_BRACKET_VIA_FILENUMBER) && defined(FEATURE_HDR_BRACKETING)
         /* Resync AFTER any bracket frames fired above, so the bracket's OWN frames (which also
          * bump file_number) don't re-trigger another bracket on the next loop iteration. */
         r_bracket_last_fn = get_shooting_card()->file_number;


### PR DESCRIPTION
## What this does

Enables working exposure (HDR) bracketing on the EOS R (FW 1.8.0), plus the shutter-control and capture pieces it needs.

## The core fix: PROP_SHUTTER encoding

On the R, `PROP_SHUTTER` is a 2-byte value whose **high byte is the shutter as a signed Tv in 1/3-stop units** (0 = 1", +3 = 0.5", -3 = 2", verified on camera). ML had been writing the value in the low byte, so the camera always saw Tv 0 and **every frame came out 1"** — which is why bracketing produced no exposure variation. This converts at the property boundary (write and read), leaving ML's internal raw scale unchanged.

## Included

- **lens.c** — hi-byte-Tv encode/decode; CONFIG_R capture via the CameraConductor remote-release event with an early return so bracket frames sequence cleanly; coerce out-of-range shutter writes to the camera limit.
- **shoot.c** — detect the user's shot via the card file_number (the R's `job_state` notifications are unreliable) to fire the bracket; read the M-mode dial via a brief half-press so the bracket centers on the user's shutter; drop the `MENU_MODE` cancel check on R; auto frame count → fixed 5-frame symmetric bracket.
- **features.h / property_whitelist.h** — enable HDR bracketing + intervalometer, allow PROP_SHUTTER.

## Comparison with #279, and why this one

#279 fixes the single-capture "saving…" hang on the R using the same CameraConductor remote-release event. This PR carries an **equivalent** capture fix and goes further:

| | #279 | This PR |
|---|---|---|
| Single-capture saving-hang fix | ✅ remote-release | ✅ same remote-release event |
| Multi-frame sequencing | falls through to the generic post-capture waits | adds a settle + **early return** that skips those waits — without it the R stalls after frame 1, so a bracket/intervalometer can't fire a sequence |
| PROP_SHUTTER encoding fix | — | ✅ hi-byte Tv (without it every frame is 1") |
| HDR exposure bracketing | — | ✅ |
| Dial-centered bracket + intervalometer | — | ✅ |
| Hardware test coverage | single capture | full 11-point matrix (comment below) |

So this is a **superset**: an equivalent remote-release capture fix, plus the early-return refinement and the shutter-encoding fix that multi-frame bracketing requires. It can replace #279, or be rebased onto it if you'd rather land #279 first — happy to do whichever.

(Minor: #279 wires the remote-release as a named stub `SetEventIrRemoteReleaseBtn`; this PR currently calls it by address `0xE0190215` with a comment — trivial to switch to the named stub if you prefer.)

## Testing

Validated on an EOS R (FW 1.8.0) — full functional matrix in the comment below (single capture, 5-frame HDR bracket centered on the dial with varying exposures, intervalometer, clean power-off).

## Known limitations

- The R doesn't report the shutter dial to ML at idle, so the bracket reads it via a brief half-press at the start (a short pause before the first frame).
- Bracketing from a very fast base (e.g. 1/2000) clamps the fast-end frames at 1/8000 (a physical limit), handled so no frame is wasted.
- Auto frame-count is a fixed 5-frame bracket on the R (the histogram auto-metering path is unreliable on this body).
