### PR TITLE
ptpcam: fix SIGINT NULL-deref crash before camera is connected

### DIFF
--- a/tools/ptpcam/ptpcam.c
+++ b/tools/ptpcam/ptpcam.c
@@ -194,11 +194,19 @@ help()
 void
 ptpcam_siginthandler(int signum)
 {
-    PTP_USB* ptp_usb=(PTP_USB *)globalparams->data;
-    struct usb_device *dev=usb_device(ptp_usb->handle);
-
     if (signum==SIGINT)
     {
+	if (globalparams==NULL)
+	{
+	    /* No camera connected yet (e.g. still enumerating USB devices),
+	     * so there is nothing to close - exit immediately rather than
+	     * dereferencing a NULL globalparams below. */
+	    exit (-1);
+	}
+
+	PTP_USB* ptp_usb=(PTP_USB *)globalparams->data;
+	struct usb_device *dev=usb_device(ptp_usb->handle);
+
 	/* hey it's not that easy though... but at least we can try! */
 	printf("Got SIGINT, trying to clean up and close...\n");
 	usleep(5000);


### PR DESCRIPTION
Fixes #65.

## What's wrong

`ptpcam_siginthandler()` dereferences `globalparams->data` unconditionally. `globalparams` is only assigned inside `init_ptp_usb()`, which runs *after* a camera has been found and opened. `signal(SIGINT, ...)` is registered earlier in `main()`, before device discovery happens.

So there's a window — USB enumeration taking a moment, or simply running `ptpcam` with no camera attached — where Ctrl+C fires the handler while `globalparams` is still `NULL`, and it segfaults instead of exiting cleanly. This reproduces 100% of the time by just starting `ptpcam` and hitting Ctrl+C immediately, no camera required.

## Fix

Guard the `NULL` case and `exit()` immediately, since there's nothing to close yet. The existing best-effort cleanup path (`close_camera()`) for an already-connected camera is unchanged.

## Testing

I don't have a compatible Canon body to drive the full PTP/USB path, but the crash itself is a plain signal-handling bug independent of any camera, so I verified the logic with an isolated repro matching the same pointer-lifecycle pattern (global set late, dereferenced unconditionally in a `SIGINT` handler):

- Before the fix: `SIGINT` before the pointer is set → segfault (confirmed).
- After the fix: `SIGINT` before the pointer is set → clean exit, no crash.
- After the fix: `SIGINT` after the pointer is set (simulating a connected camera) → existing cleanup path still runs unchanged.

Scoped narrowly to the crash itself rather than a broader signal-safety rewrite of `close_camera()`'s libusb calls — that's a bigger change that probably belongs with #51 (general ptpcam refactor) rather than this fix.
