### PR TITLE
modules: fix module build on Python 3.12+

### DIFF
--- a/modules/readme2modulestrings.py
+++ b/modules/readme2modulestrings.py
@@ -4,6 +4,7 @@
 import sys, re
 import subprocess
 import os
+import shutil
 from datetime import datetime
 
 from align_string_proportional import word_wrap
@@ -61,9 +62,7 @@ def declare_string_section():
     
 def is_command_available(name):
     """Check if command `name` is on PATH."""
-    import distutils.spawn
-    from distutils.spawn import find_executable
-    return find_executable(name) is not None
+    return shutil.which(name) is not None
 
 # return the first command of the list that can be found on the OS
 def get_command_of(commands):


### PR DESCRIPTION
I am playing around with AI agents (specifically claude code) to automate away annoying and boring side tasks and to pay off some technical debt so this PR is AI assisted. Please let me know what you think about this kind of PRs and if this could be useful for ML. I've tried to keep change sets small and reviewable.

Motivation is to fix the build issue of https://github.com/reticulatedpines/magiclantern_simplified/issues/286. While trying to build ML on my Arch machine, I did run into some other issues which were fixed by the AI as well. Even though everything is part of the build fix, I have split them up into seperate PRs in case the AI made wrong assumptions.

Here is the AIs report:

## modules: fix module build on Python 3.12+

  ### What
  Replace `distutils.spawn.find_executable` with `shutil.which` in
  `modules/readme2modulestrings.py`.

  ### Why
  `distutils` was deprecated in Python 3.10 and removed from the stdlib in 3.12
  (PEP 632). On any distro shipping Python >= 3.12 the script dies before emitting
  anything:

  ModuleNotFoundError: No module named 'distutils'

  This looks like a docs problem but is not. `module_strings.h` is generated from
  each module's `README.rst` and compiled into the `.mo`, where it supplies the
  Name/Author/License/Summary text shown in the Modules menu — and
  `modules/Makefile:182` makes *every* module object depend on it. When the script
  fails, no module builds at all and no cam can produce `magiclantern.zip`.

  Debian trixie (Python 3.13) hits this out of the box; so does current Arch.

  ### Compatibility
  `shutil.which` is stdlib since Python 3.3. The script already required 3.3+ (it
  catches `FileNotFoundError`) and is python3-only (shebang, plus
  `PYTHON = python3` in `Makefile.globals`), so the minimum supported version is
  unchanged and there is no longer an upper bound. No f-strings or walrus
  operators anywhere in the script or the local modules it imports, so 3.3 remains
  the true floor.

  `shutil.which` is also the more correct test: `find_executable` does not check
  the execute bit on POSIX, so a non-executable `rst2html` would previously have
  been reported as found, then failed when the build tried to run it.

  Installing `setuptools` for its `distutils` shim would only defer the problem —
  that shim is itself deprecated and slated for removal.

  The script still needs `rst2html` on PATH (`python3-docutils` or your distro's
  equivalent); that dependency is unchanged.

  ### Testing
  Built `platform/200D.101` with `arm-none-eabi-gcc 15.2.1`: all 23 default
  modules and `magiclantern.zip`. Not tested on a physical camera — this only
  affects host-side build tooling and cannot change emitted code.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)