### PR TITLE
gcc 16: silence set-but-unused warnings on kept counters

### DIFF
--- a/modules/raw_video/mlv_rec/mlv_rec.c
+++ b/modules/raw_video/mlv_rec/mlv_rec.c
@@ -3436,7 +3436,8 @@ static void raw_video_rec_task()
         }
 
         uint32_t used_slots = 0;
-        uint32_t writing_slots = 0;
+        /* kept for the commented-out trace_write below */
+        uint32_t UNUSED_ATTR(writing_slots) = 0;
         uint32_t queued_writes = 0;
 
         /* this will enable the vsync CBR and the other task(s) */

--- a/modules/selftest/selftest.c
+++ b/modules/selftest/selftest.c
@@ -1375,7 +1375,8 @@ static void thread_test_task(void* arg)
 
 static void rpc_test_task(void* unused)
 {
-    uint32_t loops = 0;
+    /* counts the RPC pings sent; kept for documentation and future use */
+    uint32_t UNUSED_ATTR(loops) = 0;
 
     ml_rpc_verbose(1);
     while(1)

--- a/src/greenscreen.c
+++ b/src/greenscreen.c
@@ -77,7 +77,7 @@ void green_screen_step()
       uint16_t * const b_row = (uint16_t*)( bm        + BM_R(y)       );  // 2 pixels
       uint16_t * const m_row = (uint16_t*)( bm_mirror + BM_R(y)       );  // 2 pixels
       
-      uint8_t* lvp; // that's a moving pointer through lv vram
+      uint8_t* UNUSED_ATTR(lvp); // that's a moving pointer through lv vram
       uint16_t* bp;  // through bmp vram
       uint16_t* mp;  // through mirror
       

--- a/src/init.c
+++ b/src/init.c
@@ -509,7 +509,8 @@ static void my_big_init_task()
     extern struct task_create _tasks_end[];
     struct task_create * task = _tasks_start;
 
-    int ml_tasks = 0;
+    /* counts the ML tasks created; kept for documentation and future use */
+    int UNUSED_ATTR(ml_tasks) = 0;
     for( ; task < _tasks_end ; task++ )
     {
 #if defined(POSITION_INDEPENDENT)

--- a/src/lvinfo.c
+++ b/src/lvinfo.c
@@ -224,7 +224,9 @@ int lvinfo_should_enlarge(struct lvinfo_item * items[], int count, int total_wid
 static REQUIRES(lvinfo_sem)
 int lvinfo_squeeze_space(struct lvinfo_item * items[], int count, int total_width)
 {
-    int used_items = 0;
+    /* counted like the sibling functions above, but this one squeezes by
+     * priority rather than dividing space; kept for documentation and future use */
+    int UNUSED_ATTR(used_items) = 0;
     int used_width = 0;
     for (int i = 0; i < count; i++)
     {

--- a/src/ml-cbr.c
+++ b/src/ml-cbr.c
@@ -224,7 +224,9 @@ int ml_unregister_cbr(const char* event, cbr_func cbr) {
     LOCK(ml_cbr_lock);
     struct cbr_record * record = find_record(event, 0);
     int retval = -1;
-    int count = 0;
+    /* only read by dbg_printf below, which compiles to nothing
+     * unless CBR debugging is enabled */
+    int UNUSED_ATTR(count) = 0;
     if (record == NULL) {
         dbg_printf("Unknown event %s\n", event);
         retval = -1;

--- a/src/module.c
+++ b/src/module.c
@@ -52,7 +52,8 @@ static int module_load_symbols(TCCState *s, char *filename)
     uint32_t size = 0;
     FILE* file = NULL;
     char *buf = NULL;
-    uint32_t count = 0;
+    /* counts the symbols loaded; kept for documentation and future use */
+    uint32_t UNUSED_ATTR(count) = 0;
     uint32_t pos = 0;
 
     if( FIO_GetFileSize( filename, &size ) != 0 )

--- a/src/rbf_font.c
+++ b/src/rbf_font.c
@@ -402,7 +402,8 @@ static int rbf_draw_string_simple(font *rbf_font, int x, int y, const char *str,
 //-------------------------------------------------------------------
 static int rbf_draw_clipped_string(font *rbf_font, int x, int y, const char *str, int fontspec, int maxlen)
 {
-    int i = 0;
+    /* counts the chars drawn; kept for documentation and future use */
+    int UNUSED_ATTR(i) = 0;
     int l = 0;
     
     int justified = (fontspec & FONT_ALIGN_MASK) == FONT_ALIGN_JUSTIFIED;

--- a/src/reboot-all.c
+++ b/src/reboot-all.c
@@ -58,7 +58,12 @@ asm(
 static void busy_wait(int n)
 {
     int i,j;
-    static volatile int k = 0;
+    /* k is written but never read; it exists only so the delay loop is
+     * not optimised away.  gcc 16 warns about it (set-but-not-used) even
+     * though k is volatile, where 15 and earlier did not, and we build
+     * with -Werror.
+     */
+    static volatile int UNUSED_ATTR(k) = 0;
     for (i = 0; i < n; i++)
         for (j = 0; j < 100000; j++)
             k++;

--- a/src/reboot.c
+++ b/src/reboot.c
@@ -152,7 +152,12 @@ extern uint32_t blob_end;
 static void busy_wait(int n)
 {
     int i,j;
-    static volatile int k = 0;
+    /* k is written but never read; it exists only so the delay loop is
+     * not optimised away.  gcc 16 warns about it (set-but-not-used) even
+     * though k is volatile, where 15 and earlier did not, and we build
+     * with -Werror.
+     */
+    static volatile int UNUSED_ATTR(k) = 0;
     for (i = 0; i < n; i++)
         for (j = 0; j < 100000; j++)
             k++;

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -379,7 +379,12 @@ task_create_##ENTRY = { \
 
 extern int ml_shutdown_requested;
 
-#define TASK_LOOP for (int k = 0; !ml_shutdown_requested ; k++)
+/* k is a loop counter most task loops never read, but some do
+ * (e.g. idle_led_blink_step(k) in zebra.c), so it cannot be removed.
+ * gcc 16 warns (set-but-not-used) at every call site that ignores it,
+ * where 15 and earlier did not, and we build with -Werror.
+ */
+#define TASK_LOOP for (int UNUSED_ATTR(k) = 0; !ml_shutdown_requested ; k++)
 
 
 const char * get_task_name_from_id(int id);


### PR DESCRIPTION
I am playing around with AI agents (specifically claude code) to automate away annoying and boring side tasks and to pay off some technical debt so this PR is AI assisted. Please let me know what you think about this kind of PRs and if this could be useful for ML. I've tried to keep change sets small and reviewable.

Motivation is to fix the build issue of https://github.com/reticulatedpines/magiclantern_simplified/issues/286. While trying to build ML on my Arch machine, I did run into some other issues which were fixed by the AI as well. Even though everything is part of the build fix, I have split them up into seperate PRs in case the AI made wrong assumptions.

Here is the AIs report:

## gcc 16: silence set-but-unused warnings on kept counters

  ### What
  Annotate eleven intentionally-unread variables with the existing `UNUSED_ATTR`
  macro from `src/compiler.h`. No statements are changed.

  ### Why
  gcc 16 broadened `-Wunused-but-set-variable`: it no longer exempts
  `volatile`-qualified variables, and it flags plain locals that 15 let through.
  ML builds with `-Werror`, so each one stops the build:

  ../../src/reboot.c:155:25: error: variable 'k' set but not used [-Werror=unused-but-set-variable=]

  Note the trailing `=` — that is the option's argument-taking form, which gcc 15
  does not recognise at all. Confirmed by compiling the same code on 15.2.1 (no
  warning) and 16.1.0 (error).

  ### Why annotated rather than deleted
  Three of these are read by code that compiles out or is not built by default, so
  deleting them would break a debug build rather than tidy it:

  - `tasks.h` — `TASK_LOOP`'s `k` is read by `idle_led_blink_step(k)` in
    `zebra.c`. 43 call sites ignore it, and those are what warn.
  - `ml-cbr.c` — `count` is read by `dbg_printf()`, which is `do {} while(0)`
    unless CBR debugging is enabled.
  - `mlv_rec.c` — `writing_slots` is read only by a commented-out `trace_write`.

  The rest (`reboot.c` / `reboot-all.c` `busy_wait`'s `k`, `module.c`,
  `rbf_font.c`, `greenscreen.c`, `init.c`, `lvinfo.c`, `selftest.c`) are counters
  kept for documentation and possible future use.

  Worth noting for reviewers: `lvinfo.c`'s `used_items` looks like a missing
  division, because the two sibling functions do `extra_spacing / used_items`.
  `lvinfo_squeeze_space` deliberately doesn't — it works from `used_width` and
  discards by priority. A comment now records that, so it doesn't get "fixed"
  later.

  ### Risk
  Purely additive — the diff adds only an attribute and comments, so camera
  behaviour is unaffected on every generation.

  ### Testing
  Built `platform/200D.101` with `arm-none-eabi-gcc 15.2.1`: all 23 default
  modules and `magiclantern.zip`. Earlier revisions of the `reboot.c` and
  `tasks.h` changes were also built with `arm-none-eabi-gcc 16.1.0`, which is
  where the warnings were first reported. Not tested on a physical camera.

  To enumerate this warning class in one pass rather than one build at a time:

  ```sh
  cd platform/200D.101
  make clean && make FATAL_WARNINGS=n -k -j$(nproc) 2>&1 | grep -E "unused-but-set|warning:" | sort -u
  ```

  🤖 Generated with Claude Code (https://claude.com/claude-code)
