### PR TITLE
ml_socket: include sys/select.h for fd_set

### DIFF
--- a/src/ml_socket.h
+++ b/src/ml_socket.h
@@ -7,6 +7,12 @@
 // I didn't want to call it socket.h, because that conflicts with a system library,
 // and ML code has a bad habit of using <blah.h> for non-system libs
 
+// for fd_set and struct timeval, used by socket_select_caller() below.
+// We used to get these by luck, via whatever the includer had already
+// pulled in; newlib 4.5 and earlier happened to provide them transitively,
+// newlib 4.6 and picolibc do not.
+#include <sys/select.h>
+
 static const int16_t SOCK_FAMILY_IPv4 = 0x100; // network order 1
 static const int16_t SOCK_FAMILY_IPv6 = 0x200;
 static const int16_t SOCK_FAMILY_ETH = 0x300;


### PR DESCRIPTION
I am playing around with AI agents (specifically claude code) to automate away annoying and boring side tasks and to pay off some technical debt so this PR is AI assisted. Please let me know what you think about this kind of PRs and if this could be useful for ML. I've tried to keep change sets small and reviewable.

Motivation is to fix the build issue of https://github.com/reticulatedpines/magiclantern_simplified/issues/286. While trying to build ML on my Arch machine, I did run into some other issues which were fixed by the AI as well. Even though everything is part of the build fix, I have split them up into seperate PRs in case the AI made wrong assumptions.

Here is the AIs report:

## ml_socket: include sys/select.h for fd_set

  ### What
  Add `#include <sys/select.h>` to `src/ml_socket.h`.

  ### Why
  `socket_select_caller()` is declared with `fd_set` and `struct timeval`
  parameters, but `ml_socket.h` includes nothing at all. It worked only because
  whatever included it had already pulled those in. newlib 4.5 provided them
  transitively; newlib 4.6 and picolibc do not, so the only user of this header
  fails to build:

  ../../src/ml_socket.h:33:48: error: unknown type name 'fd_set'

  Both libcs define `fd_set` in `<sys/select.h>` (via `sys/_select.h`), which also
  brings in `struct timeval`.

  ### Relationship to #286
  Same era, opposite direction. The lua breakage is one of *our* bundled headers
  shadowing the toolchain's; this is one of *our* headers failing to include what
  it uses. They need separate fixes and this one is not sufficient for that issue.

  ### Risk
  `modules/yolo` is the only file that includes `ml_socket.h`, so the blast radius
  is one module.

  ### Testing
  Built `platform/200D.101` with `arm-none-eabi-gcc 15.2.1` from a clean tree: all
  23 default modules and `magiclantern.zip`. Not tested on a physical camera.

  Worth knowing: this failure hides behind stale objects. A `yolo.o` built before a
  toolchain change will be reused and the build appears to pass — it only shows up
  after `make clean`.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
