### PR TITLE
feat: enable LJ92 lossless compression on Digic 4 bodies

### DIFF
--- a/modules/raw_video/mlv_lite/mlv_lite.c
+++ b/modules/raw_video/mlv_lite/mlv_lite.c
@@ -364,6 +364,56 @@ static volatile                 uint32_t skip_frames = 0;
 /* for compress_task */
 static struct msg_queue * compress_mq = 0;
 
+/* In-flight compression jobs and first failed frame. Used to drain the queue
+ * cleanly on a compression fault and to drop any later frames already captured. */
+static volatile unsigned int compression_pending_jobs = 0;
+static volatile int compression_first_failed_frame = INT_MAX;
+
+#define COMPRESS_JOB_TRACKED 0x40000000
+#define COMPRESS_JOB_WARMUP  0x20000000
+
+/* Frames the encoder runs over and throws away before a compressed clip starts.
+ *
+ * The first encode of a clip swaps a set of LiveView registers over to our
+ * geometry, and LiveView needs a few frames to relock: in every DIGIC 4 lossless
+ * clip VIDF 1 to 4 came out shredded into bands of about sixteen rows while the
+ * vsync interval wobbled between 37.8 and 45.1 ms, and both the damage and the
+ * wobble stopped at VIDF 5. Uncompressed clips, which never touch those
+ * registers, are clean from VIDF 0.
+ *
+ * Skipping the frames outright would not help, because it is the first encode
+ * that disturbs LiveView - the transient would just move to wherever the first
+ * kept frame is. So encode over the unstable window with the results binned. */
+#define COMPRESS_WARMUP_FRAMES  6
+static volatile int warmup_frames = 0;
+
+static int count_free_slots(void);
+
+static void compression_job_admit(void)
+{
+    uint32_t old_int = cli();
+    compression_pending_jobs++;
+    sei(old_int);
+}
+
+static void compression_job_retire(void)
+{
+    uint32_t old_int = cli();
+    if (compression_pending_jobs)
+        compression_pending_jobs--;
+    sei(old_int);
+}
+
+static void compression_record_fault(int frame_number, int code)
+{
+    uint32_t old_int = cli();
+    if (compression_first_failed_frame == INT_MAX)
+        compression_first_failed_frame = frame_number;
+    buffer_full = 1;
+    sei(old_int);
+    (void) code;
+}
+
 static GUARDED_BY(RawRecTask)   mlv_file_hdr_t file_hdr[CARD_COUNT];
 static GUARDED_BY(RawRecTask)   mlv_rawi_hdr_t rawi_hdr;
 static GUARDED_BY(RawRecTask)   mlv_rawc_hdr_t rawc_hdr;
@@ -697,6 +747,16 @@ void update_resolution_params()
         res_x = max_res_x;
     }
 
+    /* JPCORE (DIGIC 4) always advances 20 samples past the encoded width, so RD1
+     * has to feed width+20 per source row to keep the rows aligned, and that row
+     * length is only a whole even number of bytes at width = 4 (mod 8).
+     * Narrowing here rather than inside the encoder keeps RAWI, the VIDF
+     * payloads and the uncompressed path describing the same frame. */
+    if (OUTPUT_COMPRESSION)
+    {
+        res_x = lossless_encodable_width(res_x);
+    }
+
     /* res Y */
     int num = aspect_ratio_presets_num[aspect_ratio_index];
     int den = aspect_ratio_presets_den[aspect_ratio_index];
@@ -716,9 +776,18 @@ void update_resolution_params()
     int frame_size_padded = (VIDF_HDR_SIZE + (res_x * res_y * BPP/8) + 4 + 511) & ~511;
     
     /* frame size without padding */
-    /* must be multiple of 4 */
     frame_size_uncompressed = res_x * res_y * BPP/8;
-    ASSERT(frame_size_uncompressed % 4 == 0);
+
+    /* Must be a multiple of 4 only where it is handed to the EDMAC as a slot
+     * payload size, which is the uncompressed path alone; compressed recording
+     * uses it as a compression-ratio denominator and a corrupt-frame bound. The
+     * DIGIC 4 encodable width (4 mod 8) makes the row length odd, so the product
+     * is 4-aligned only at heights that are a multiple of 4 - not a constraint
+     * worth putting on the framing when nothing reads the value that way. */
+    if (!OUTPUT_COMPRESSION)
+    {
+        ASSERT(frame_size_uncompressed % 4 == 0);
+    }
     
     max_frame_size = frame_size_padded;
 
@@ -934,6 +1003,17 @@ void setup_bit_depth_digital_gain(int force_off)
         bpp_d = 14;
     }
 
+    if (OUTPUT_COMPRESSION && get_digic_version() == 4)
+    {
+        /* Attenuate in the encoder's own gain stage instead. raw.c's digital
+         * gain is inert here in the direction it wants and harmful in another:
+         * SHAD_GAIN never reaches the slurp, while the ISO boost that is meant
+         * to compensate for it does reach the sensor data, which is how 12-bit
+         * came out 4x bright and 11-bit 8x. */
+        lossless_d4_set_target_bpp(bpp_d);
+        bpp_d = 14;
+    }
+
     if (bpp_d != prev_bpp_d)
     {
         int div = 1 << (14 - bpp_d);
@@ -962,6 +1042,19 @@ void restore_bit_depth()
 static void measure_compression_ratio()
 {
     ASSERT(RAW_IS_IDLE);
+
+    /* DIGIC 4 borrows Evf's JPCORE to encode, which corrupts the preview until
+     * LiveView is restarted. That is a fair price while recording, but not for a
+     * measurement taken twice a second in standby, so this one keeps the estimate
+     * from the table below. Measured ratio on a 600D is ~53%, against the 60% the
+     * table assumes for 14-bit lossless - the buffer prediction errs large.
+     *
+     * Not is_camera("DIGIC", "4"): that compares the model short name, so it reads
+     * "600D" == "DIGIC" and is never true. */
+    if (get_digic_version() == 4)
+    {
+        return;
+    }
 
     /* compress the current frame to estimate the ratio */
     /* assume we have at least one valid slot */
@@ -1545,8 +1638,13 @@ int setup_buffers()
     /* the EDMAC on old models might copy a little more,
      * depending on how the EDMAC size was interpreted back then
      * todo: double-check (for now, allocate a bit more, just in case)
+     *
+     * The lossless encoder reads further still: its input EDMAC runs past the
+     * bottom of the rectangle to flush the pipeline, so the tail has to stay
+     * inside this buffer rather than in whatever slot the allocator put next.
      */
-    int fullres_buf_size = raw_info.width * (raw_info.height + 2) * BPP/8;
+    int spare_rows = 2 + (OUTPUT_COMPRESSION ? lossless_input_overread_rows() : 0);
+    int fullres_buf_size = raw_info.width * (raw_info.height + spare_rows) * BPP/8;
 
     int pre_recording_settings = pre_record | (rec_trigger << 8);
 
@@ -2586,6 +2684,13 @@ int get_frame_save_status(int slot_index)
     ASSERT(slots[slot_index].ptr);
     void* ptr = slots[slot_index].ptr + VIDF_HDR_SIZE;
     uint32_t edmac_size = (slots[slot_index].payload_size + 3) & ~3;
+
+    /* empty / failed-compress frame: nothing to validate */
+    if (edmac_size < 4)
+    {
+        return 1;
+    }
+
     uint32_t* frame_end = ptr + edmac_size - 4;
     uint32_t* after_frame = ptr + edmac_size;
     if (*(volatile uint32_t*) after_frame != FRAME_SENTINEL)
@@ -2698,6 +2803,44 @@ static void edmac_cbr_w(void *ctx)
     edmac_copy_rectangle_adv_cleanup();
 }
 
+/* Output MemorySuite for compressed frames. CreateMemorySuite is not free, and
+ * rolling slot reuse often lands on the same address again, so keep one suite
+ * alive and only rebuild when the pointer or size changes. Cleared at record
+ * start/stop so a stale suite cannot outlive the underlying slot. */
+static struct memSuite * compress_out_suite;
+static void * compress_out_ptr;
+static int compress_out_size;
+
+static void compress_out_suite_reset(void)
+{
+    if (compress_out_suite)
+    {
+        DeleteMemorySuite(compress_out_suite);
+        compress_out_suite = 0;
+    }
+    compress_out_ptr = 0;
+    compress_out_size = 0;
+}
+
+static struct memSuite * compress_out_suite_get(void * out_ptr, int size)
+{
+    if (compress_out_suite &&
+        compress_out_ptr == out_ptr &&
+        compress_out_size == size)
+    {
+        return compress_out_suite;
+    }
+
+    compress_out_suite_reset();
+    compress_out_suite = CreateMemorySuite(out_ptr, size, 0);
+    if (compress_out_suite)
+    {
+        compress_out_ptr = out_ptr;
+        compress_out_size = size;
+    }
+    return compress_out_suite;
+}
+
 static void compress_task()
 {
     ASSERT(compress_mq == 0);
@@ -2717,6 +2860,8 @@ static void compress_task()
         {
             /* start recording */
 
+            compress_out_suite_reset();
+
             if (OUTPUT_COMPRESSION == 0)
             {
                 /* get exclusive access to our edmac channels */
@@ -2731,7 +2876,9 @@ static void compress_task()
 
         if (msg == (uint32_t) INT_MIN)
         {
-            /* stop_recording */
+            /* stop_recording (or end of idle measure) */
+
+            compress_out_suite_reset();
 
             if (OUTPUT_COMPRESSION == 0)
             {
@@ -2744,6 +2891,10 @@ static void compress_task()
 
             continue;
         }
+
+        int tracked_job = (msg & COMPRESS_JOB_TRACKED) != 0;
+        int warmup_job = (msg & COMPRESS_JOB_WARMUP) != 0;
+        msg &= ~(COMPRESS_JOB_TRACKED | COMPRESS_JOB_WARMUP);
 
         int slot_index = msg & 0xFFFF;
         if (slot_index < 0)
@@ -2765,7 +2916,7 @@ static void compress_task()
             /* PackMem appears to require stricter memory alignment */
             ASSERT(((uint32_t)out_ptr & 0x3F) == 0);
             ASSERT((max_frame_size & 0xFFF) == 0);
-            struct memSuite * outSuite = CreateMemorySuite(out_ptr, max_frame_size, 0);
+            struct memSuite * outSuite = compress_out_suite_get(out_ptr, max_frame_size);
             ASSERT(outSuite);
 
             int compressed_size = lossless_compress_raw_rectangle(
@@ -2774,43 +2925,64 @@ static void compress_task()
                 res_x, res_y
             );
 
-            /* only report compression errors while recording
-             * some of them appear during video mode switches
-             * unlikely to cause actual trouble - silence them for now */
-            if (compressed_size < 0 && !RAW_IS_IDLE)
+            if (warmup_job)
             {
-                printf("Compression error %d at frame %d\n", compressed_size, frame_count-1);
-                ASSERT(0);
+                /* The output goes in the bin and a failure is not a fault: the
+                 * point of this frame was to make LiveView relock, not to keep
+                 * an image. The slot was never shrunk, so it goes straight back
+                 * to SLOT_FREE. */
+                free_slot(slot_index);
+                continue;
             }
 
-            DeleteMemorySuite(outSuite);
-
-            if (1)
+            if (compressed_size < 0)
             {
-                if (compressed_size >= frame_size_uncompressed)
+                /* Idle measure does not put the slot on the writing queue. */
+                if (RAW_IS_IDLE)
                 {
-                    printf("\nCompressed size higher than uncompressed - corrupted frame?\n");
-                    printf("Please reboot, then decrease vertical resolution in crop_rec menu.\n\n");
-                    buffer_full = 1;
-                    ASSERT(0);
-                }
-                else if (compressed_size > max_frame_size - VIDF_HDR_SIZE - 4)
-                {
-                    printf("Compressed size too high - too much detail or noise?\n");
-                    printf("Consider using uncompressed 10/12-bit.");
-                    buffer_full = 1;
-                    ASSERT(0);
+                    free_slot(slot_index);
+                    if (tracked_job)
+                        compression_job_retire();
+                    continue;
                 }
 
-                /* resize frame slots on the fly, to compressed size */
-                if (!RAW_IS_IDLE)
-                {
-                    shrink_slot(slot_index, MIN(compressed_size, max_frame_size - VIDF_HDR_SIZE - 4));
-                }
-                
-                /* our old EDMAC check assumes frame sizes known in advance - not the case here */
-                frame_fake_edmac_check(slot_index);
+                bmp_printf(FONT_MED, 30, 110, "Compression error %d ", compressed_size);
+                printf("Compression error %d at frame %d\n",
+                       compressed_size, slots[slot_index].frame_number - 1);
+                compression_record_fault(slots[slot_index].frame_number,
+                                        compressed_size);
+                if (tracked_job)
+                    compression_job_retire();
+                continue;
             }
+
+            if (compressed_size >= frame_size_uncompressed)
+            {
+                printf("\nCompressed size higher than uncompressed - corrupted frame?\n");
+                printf("Please reboot, then decrease vertical resolution in crop_rec menu.\n\n");
+                compression_record_fault(slots[slot_index].frame_number, compressed_size);
+                if (tracked_job)
+                    compression_job_retire();
+                continue;
+            }
+            else if (compressed_size > max_frame_size - VIDF_HDR_SIZE - 4)
+            {
+                printf("Compressed size too high - too much detail or noise?\n");
+                printf("Consider using uncompressed 10/12-bit.");
+                compression_record_fault(slots[slot_index].frame_number, compressed_size);
+                if (tracked_job)
+                    compression_job_retire();
+                continue;
+            }
+
+            /* resize frame slots on the fly, to compressed size */
+            if (!RAW_IS_IDLE)
+            {
+                shrink_slot(slot_index, MIN(compressed_size, max_frame_size - VIDF_HDR_SIZE - 4));
+            }
+
+            /* our old EDMAC check assumes frame sizes known in advance - not the case here */
+            frame_fake_edmac_check(slot_index);
 
             if (compressed_size > 0)
             {
@@ -2831,6 +3003,28 @@ static void compress_task()
         
         /* mark it as completed */
         slots[slot_index].status = SLOT_FULL;
+        if (tracked_job)
+            compression_job_retire();
+    }
+}
+
+/* One encode whose result is discarded; see COMPRESS_WARMUP_FRAMES. */
+static REQUIRES(LiveViewTask) FAST
+void compress_warmup_frame(int next_fullsize_buffer_pos)
+{
+    int slot = choose_next_capture_slot();
+
+    if (slot < 0)
+        return;
+
+    capture_slot = slot;
+    slots[slot].frame_number = 0;
+    slots[slot].status = SLOT_CAPTURING;
+
+    if (msg_queue_post(compress_mq,
+                       slot | (next_fullsize_buffer_pos << 16) | COMPRESS_JOB_WARMUP))
+    {
+        free_slot(slot);
     }
 }
 
@@ -2841,6 +3035,15 @@ void process_frame(int next_fullsize_buffer_pos)
     if (frame_count <= 0)
     {
         frame_count++;
+        return;
+    }
+
+    /* Ahead of MLV_REC_EVENT_STARTED so audio still starts alongside the first
+     * frame that is kept, rather than a quarter of a second before it. */
+    if (warmup_frames > 0)
+    {
+        warmup_frames--;
+        compress_warmup_frame(next_fullsize_buffer_pos);
         return;
     }
 
@@ -2905,7 +3108,7 @@ void process_frame(int next_fullsize_buffer_pos)
     }
     else
     {
-        /* card too slow */
+        /* card too slow / no free slots */
         buffer_full = 1;
         return;
     }
@@ -2925,7 +3128,26 @@ void process_frame(int next_fullsize_buffer_pos)
     /* for some reason, compression cannot be started from vsync */
     /* let's delegate it to another task */
     ASSERT(compress_mq);
-    msg_queue_post(compress_mq, capture_slot | (next_fullsize_buffer_pos << 16));
+    uint32_t compress_msg = capture_slot | (next_fullsize_buffer_pos << 16);
+    if (OUTPUT_COMPRESSION)
+    {
+        compression_job_admit();
+        int post_error = msg_queue_post(
+            compress_mq, compress_msg | COMPRESS_JOB_TRACKED
+        );
+        if (post_error)
+        {
+            compression_job_retire();
+            compression_record_fault(slots[capture_slot].frame_number, -1);
+            printf("Compression queue full at frame %d\n",
+                   slots[capture_slot].frame_number - 1);
+            return;
+        }
+    }
+    else
+    {
+        msg_queue_post(compress_mq, compress_msg);
+    }
 
     /* advance to next frame */
     frame_count++;
@@ -3120,12 +3342,30 @@ void init_mlv_chunk_headers(struct raw_info *raw_info)
     rawi_hdr.raw_info.bits_per_pixel = BPP;
     rawi_hdr.raw_info.pitch = rawi_hdr.raw_info.width * BPP / 8;
 
-    /* scale black and white levels, minimizing the roundoff error */
     int black14 = rawi_hdr.raw_info.black_level;
     int white14 = rawi_hdr.raw_info.white_level;
-    int bpp_scaling = (1 << (14 - BPP));
-    rawi_hdr.raw_info.black_level = (black14 + bpp_scaling/2) / bpp_scaling;
-    rawi_hdr.raw_info.white_level = (white14 + bpp_scaling/2) / bpp_scaling;
+
+    if (OUTPUT_COMPRESSION)
+    {
+        /* The container is 14-bit here whatever the menu says, so nothing is
+         * truncated; what does move the levels is the encoder's input stage,
+         * which on DIGIC 4 re-pedestals and gains. lossless.c owns the gain, so
+         * it owns the mapping; it is the identity elsewhere.
+         *
+         * No BPP_D term either. On DIGIC 4 the reduced depths attenuate in that
+         * same encoder gain stage rather than through raw.c's digital gain, so
+         * raw_info stays at full scale and the whole depth reduction shows up in
+         * the mapping. Adding BPP_D would count it twice. */
+        rawi_hdr.raw_info.black_level = lossless_d4_map_level(black14, black14);
+        rawi_hdr.raw_info.white_level = lossless_d4_map_level(white14, black14);
+    }
+    else
+    {
+        /* scale black and white levels, minimizing the roundoff error */
+        int scaling = 1 << (14 - BPP);
+        rawi_hdr.raw_info.black_level = (black14 + scaling/2) / scaling;
+        rawi_hdr.raw_info.white_level = (white14 + scaling/2) / scaling;
+    }
 
     mlv_fill_idnt(&idnt_hdr, mlv_start_timestamp);
     mlv_fill_expo(&expo_hdr, mlv_start_timestamp);
@@ -3340,9 +3580,13 @@ void init_vsync_vars()
 {
     frame_count = use_h264_proxy() ? -1 : 0;    /* see setparam_cbr */
     capture_slot = -1;
+    warmup_frames = (OUTPUT_COMPRESSION && get_digic_version() == 4)
+                  ? COMPRESS_WARMUP_FRAMES : 0;
     fullsize_buffer_pos = 0;
     edmac_active = 0;
     skipped_frames = 0;
+    compression_pending_jobs = 0;
+    compression_first_failed_frame = INT_MAX;
 }
 
 static REQUIRES(RawRecTask) EXCLUDES(settings_sem)
@@ -3800,8 +4044,18 @@ abort_and_check_early_stop:
     /* wait until the other tasks calm down */
     wait_lv_frames(2);
 
-    /* signal end of recording to the compression task */
-    msg_queue_post(compress_mq, INT_MIN);
+    /* The compression task owns source and destination slots until every admitted
+     * frame retires. Do not flush or free those buffers underneath it. */
+    while (compression_pending_jobs)
+    {
+        msleep(10);
+    }
+
+    /* The frame queue is now drained, so this control message cannot be crowded out. */
+    if (msg_queue_post(compress_mq, INT_MIN))
+    {
+        printf("Could not stop compression task.\n");
+    }
 
     set_recording_custom(CUSTOM_RECORDING_NOT_RECORDING);
 
@@ -3850,12 +4104,19 @@ abort_and_check_early_stop:
             if (slot_index < 0)
                 continue;
 
+            if (!slots[slot_index].is_meta &&
+                slots[slot_index].frame_number >= compression_first_failed_frame)
+            {
+                continue;
+            }
+
             if (slots[slot_index].status != SLOT_FULL)
             {
                 bmp_printf( FONT_MED, 30, 110, 
                     "Slot %d: frame %d not saved ", slot_index, slots[slot_index].frame_number
                 );
                 beep();
+                continue;
             }
 
             /* video frame consistency checks only for VIDF */
@@ -4548,12 +4809,13 @@ static unsigned int raw_rec_init()
         raw_video_menu->children[11].shidden = 1; // Hide "Small hacks"
         small_hacks = 0;
     }
-    if (version != 5)
-    { // so far, only Digic 5 has working lossless compression, hide on other cams
+    if (!lossless_init())
+    { // used to be "Digic 5 only", but it is a per-model question: the 600D is Digic 4 and
+      // its encoder does lossless too, so ask lossless.c whether it knows this body
         if (raw_video_menu->children[2].max > 2)
         {
             raw_video_menu->children[2].max = 2; // hide lossless options, which are 3, 4, 5
-            output_format = 0; // plain 14-bit, no lossless support on D4, D678 (yet)
+            output_format = 0; // plain 14-bit, no lossless support here
         }
     }
 
@@ -4582,8 +4844,6 @@ static unsigned int raw_rec_init()
     
     /* allocate queue that other modules will fill with blocks to write to the current file */
     mlv_block_queue = msg_queue_create("mlv_block_queue", 100);
-
-    lossless_init();
 
     settings_sem = create_named_semaphore(NULL, SEM_CREATE_UNLOCKED);
     if (is_card_spanning_possible)

--- a/modules/raw_video/mlv_lite/mlv_lite.c
+++ b/modules/raw_video/mlv_lite/mlv_lite.c
@@ -153,6 +153,10 @@ static CONFIG_INT("raw.dolly", dolly_mode, 0);
 #define FRAMING_PANNING (dolly_mode == 1)
 
 static CONFIG_INT("raw.preview", preview_mode, 0);
+/* DIGIC 4 lossless soft preview: 0 = off, 1 = gray ~5 fps, 2 = color ~2.5 fps */
+static CONFIG_INT("raw.d4.soft.preview", d4_soft_preview_mode, 1);
+#define D4_SOFT_PREVIEW_OFF   (d4_soft_preview_mode == 0)
+#define D4_SOFT_PREVIEW_COLOR (d4_soft_preview_mode == 2)
 #define PREVIEW_AUTO   (preview_mode == 0)
 #define PREVIEW_CANON  (preview_mode == 1)
 #define PREVIEW_ML     (preview_mode == 2)
@@ -2188,6 +2192,16 @@ unsigned int raw_rec_polling_cbr(unsigned int unused)
 
 static void unhack_liveview_vsync(int unused);
 
+/* Digic 4 lossless freezes Canon's Evf display branch (shared JPCORE). Defined
+ * early so hack_liveview_vsync can silence the LV EDMACs the same way Frozen LV
+ * does. Soft preview then paints into whatever buffer the LCD is already
+ * scanning (raw_preview dest -1). */
+static int d4_lossless_preview_active(void)
+{
+    return get_digic_version() == 4 && OUTPUT_COMPRESSION && RAW_IS_RECORDING
+        && !D4_SOFT_PREVIEW_OFF;
+}
+
 static REQUIRES(LiveViewTask)
 void FAST hack_liveview_vsync()
 {
@@ -2227,7 +2241,7 @@ void FAST hack_liveview_vsync()
         }
     }
     
-    if (!PREVIEW_HACKED) return;
+    if (!PREVIEW_HACKED && !d4_lossless_preview_active()) return;
     
     if (RAW_IS_RECORDING && frame_count == 0)
     {
@@ -4326,8 +4340,8 @@ static struct menu_entry raw_video_menu[] =
                 .max = 3,
                 .choices = CHOICES("Auto", "Real-time", "Framing", "Frozen LV"),
                 .help  = "Raw video preview (long half-shutter press to override):",
-                .help2 = "Auto: ML chooses what's best for each video mode\n"
-                         "Plain old LiveView (color and real-time). Framing is not always correct.\n"
+                .help2 = "Auto: ML chooses what's best for each video mode. On DIGIC 4 lossless, this preview is replaced by 'Soft preview' while recording.\n"
+                         "Plain old LiveView (color and real-time). Freezes during DIGIC 4 lossless; Framing is not always correct.\n"
                          "Slow (not real-time) and low-resolution, but has correct framing.\n"
                          "Freeze LiveView for more speed; uses 'Framing' preview if Global Draw ON.\n",
                 .depends_on = DEP_GLOBAL_DRAW,
@@ -4397,6 +4411,17 @@ static struct menu_entry raw_video_menu[] =
                 .priv = &small_hacks,
                 .max = 1,
                 .help  = "Slow down Canon GUI, disable auto exposure, white balance...",
+                .advanced = 1,
+            },
+            {
+                .name = "Soft preview",
+                .priv = &d4_soft_preview_mode,
+                .max = 2,
+                .choices = CHOICES("OFF", "Gray (5 fps)", "Color (2.5 fps)"),
+                .help  = "DIGIC 4 lossless only: repaint LiveView while recording.",
+                .help2 = "OFF: Canon LiveView stays frozen from the first encode.\n"
+                         "Gray: cheap grayscale repaint, about 5 fps.\n"
+                         "Color: ~16x the CPU of gray, so it repaints at half the rate.\n",
                 .advanced = 1,
             },
             {
@@ -4609,6 +4634,14 @@ static int raw_rec_should_preview(void)
     /* keep x10 mode unaltered, for focusing */
     if (lv_dispsize == 10) return 0;
 
+    /* Digic 4 lossless does not use the display-filter preview: the core only
+     * invokes CBR_DISPLAY_FILTER when display_filter_get_buffers() can hand out
+     * a source buffer, and that requires REG_EDMAC_WRITE_LV_ADDR to keep moving.
+     * LiveView is frozen (and we silence those EDMACs ourselves), so the address
+     * is static and the CBR is never called with a paint request.
+     * d4_soft_preview_task paints instead. */
+    if (d4_lossless_preview_active()) return 0;
+
     /* framing is incorrect in modes with high resolutions
      * (e.g. x5 zoom, crop_rec) */
     int raw_active_width = raw_info.active_area.x2 - raw_info.active_area.x1;
@@ -4680,6 +4713,73 @@ static int raw_rec_should_preview(void)
     return 0;
 }
 
+/* Digic 4 lossless soft preview: best-effort ~5 Hz paint from our own task.
+ *
+ * This cannot ride CBR_DISPLAY_FILTER. The core only issues a paint request when
+ * display_filter_get_buffers() yields a source buffer, and that source is "the
+ * previous LV buffer", detected by watching REG_EDMAC_WRITE_LV_ADDR change. Once
+ * the first encode freezes Evf (and once we silence the LV EDMACs), that address
+ * is constant, so src_buf stays NULL and module_display_filter_update() skips
+ * the handler forever.
+ *
+ * Painting from a private task also drops the Global Draw / zebra dependency. */
+static EXCLUDES(settings_sem)
+void d4_soft_preview_paint(void)
+{
+    int queued_frames = MOD(writing_queue_tail - writing_queue_head, COUNT(writing_queue));
+    int free_slots = count_free_slots();
+
+    /* A non-empty writing queue is the healthy steady state, not backlog.
+     * Skip only on real backlog. */
+    int backlog = queued_frames > valid_slot_count / 2;
+    int slots_low = free_slots <= valid_slot_count / 4;
+    int soft_skip = backlog || slots_low || buffer_full;
+
+    if (soft_skip)
+    {
+        msleep(400);
+        return;
+    }
+
+    static int fi = 0; fi = !fi;
+
+    take_semaphore(settings_sem, 0);
+
+    raw_set_preview_rect(skip_x, skip_y, res_x, res_y, 1);
+    raw_force_aspect_ratio(0, 0);
+
+    /* Color costs roughly 16x gray: full-res vertically, twice the columns, and
+     * 6 raw reads plus rgb2yuv422() per output pixel instead of one LUT. Half
+     * shutter promotes gray to color for a focus check. */
+    int color = D4_SOFT_PREVIEW_COLOR || get_halfshutter_pressed();
+    int quality = color
+        ? RAW_PREVIEW_COLOR_HALFRES
+        : RAW_PREVIEW_GRAY_ULTRA_FAST;
+
+    /* dest -1 resolves to YUV422_LV_BUFFER_DISPLAY_ADDR inside raw.c: one paint,
+     * into the buffer the panel is scanning. */
+    raw_preview_fast_ex(fullsize_buffers[fi], (void *)-1, -1, -1, quality);
+
+    give_semaphore(settings_sem);
+
+    /* color is far heavier, so give the recorder twice as much room between paints */
+    msleep(color ? 400 : 200);
+}
+
+static void d4_soft_preview_task(void)
+{
+    TASK_LOOP
+    {
+        if (!d4_lossless_preview_active())
+        {
+            msleep(200);
+            continue;
+        }
+
+        d4_soft_preview_paint();
+    }
+}
+
 static REQUIRES(LiveVHiPrioTask) EXCLUDES(settings_sem)
 unsigned int raw_rec_update_preview(unsigned int ctx)
 {
@@ -4698,8 +4798,9 @@ unsigned int raw_rec_update_preview(unsigned int ctx)
         return enabled;
     }
 
-    /* only consider speed when the recorder is actually busy */
     int queued_frames = MOD(writing_queue_tail - writing_queue_head, COUNT(writing_queue));
+
+    /* only consider speed when the recorder is actually busy */
     int need_for_speed = (RAW_IS_RECORDING) && (
         (PREVIEW_HACKED && queued_frames > valid_slot_count / 8) ||
         (queued_frames > valid_slot_count / 4)
@@ -4720,9 +4821,15 @@ unsigned int raw_rec_update_preview(unsigned int ctx)
     /* when recording, preview both full-size buffers,
      * to make sure it's not recording every other frame */
     static int fi = 0; fi = !fi;
+    /* Frozen LV paints into the buffer the LCD is already scanning. */
+    void * dst = buffers->dst_buf;
+    if (PREVIEW_HACKED && RAW_IS_RECORDING)
+    {
+        dst = (void *)-1;
+    }
     raw_preview_fast_ex(
         RAW_IS_RECORDING ? fullsize_buffers[fi] : (void*)-1,
-        PREVIEW_HACKED && RAW_IS_RECORDING ? (void*)-1 : buffers->dst_buf,
+        dst,
         -1,
         -1,
         (need_for_speed && !get_halfshutter_pressed())
@@ -4851,6 +4958,11 @@ static unsigned int raw_rec_init()
 
     ASSERT(((uint32_t)task_create("compress_task", 0x0F, 0x1000, compress_task, (void*)0) & 1) == 0);
 
+    /* Low priority: the soft preview must never delay capture or encode.
+     * Stack must clear raw_preview_color_work's two 1024-byte gamma tables plus
+     * call frames; a 0x800 stack crashed the camera as soon as Color was picked. */
+    task_create("d4_soft_preview", 0x1F, 0x2000, d4_soft_preview_task, (void*)0);
+
     return 0;
 }
 
@@ -4884,6 +4996,7 @@ MODULE_CONFIGS_START()
     MODULE_CONFIG(card_spanning)
     MODULE_CONFIG(dolly_mode)
     MODULE_CONFIG(preview_mode)
+    MODULE_CONFIG(d4_soft_preview_mode)
     MODULE_CONFIG(use_srm_memory)
     MODULE_CONFIG(small_hacks)
     MODULE_CONFIG(warm_up)

--- a/modules/silent/lossless.c
+++ b/modules/silent/lossless.c
@@ -3,6 +3,7 @@
 #include "lens.h"
 #include "raw.h"
 #include "edmac.h"
+#include "timer.h"
 
 struct TwoInTwoOutLosslessPath_args
 { 
@@ -54,6 +55,7 @@ struct TwoInTwoOutLosslessPath_args
 
 static struct TwoInTwoOutLosslessPath_args TTL_Args;
 static struct LockEntry * TTL_ResLock = 0;
+static struct LockEntry * TTL_ResLock_shared = 0;   /* DIGIC 4; see lossless_init */
 static struct semaphore * lossless_sem = 0;
 static int verbose = 0;
 
@@ -67,18 +69,169 @@ static void LosslessCompleteCBR()
 #define PACK32(lo,hi) (((uint32_t)(lo) & 0xFFFF) | ((uint32_t)(hi) << 16))
 
 static void (*TTL_SetArgs)(int unused, void * TTL_Args, int PictureSize) = NULL;
-static void (*TTL_Prepare)(void * ResLock, void * TTL_Args) = NULL;
+static int  (*TTL_Prepare)(void * ResLock, void * TTL_Args) = NULL;
 static void (*TTL_RegisterCBR)(int id, void * cbr, void * cbr_arg) = NULL;
 static void (*TTL_SetFlags)(int PictureType) = NULL;
 static void (*TTL_Start)(void * TTL_Args) = NULL;
 static void (*TTL_Stop)(void * TTL_Args) = NULL;
 static void (*TTL_Finish)(void * ResLock, void * TTL_Args, uint32_t * output_size) = NULL;
 
+/* DIGIC 4 only; both stay NULL on every other model. Measured on a 600D, Canon's
+ * ProcessTwoInTwoOutJpegPath differs from the DIGIC 5 one in three ways:
+ *
+ *  - Start is split in two. TTL_Start configures JPCORE and runs Canon's engio
+ *    lists, reprogramming RD1 from the args struct; only TTL_StartJpCore starts
+ *    the encoder and the input EDMAC. Our register overrides have to go between
+ *    the two, or Canon's full-res values win.
+ *
+ *  - the pipeline ahead of the encoder holds back input, so it has to be fed past
+ *    the end of the frame to push the last real rows through (D4_GEO_PIPELINE_ROWS).
+ *
+ *  - Completion is unreliable: JPCORE's 0x400 interrupt often never fires. Keep a
+ *    stall detector as the completion path: when the output pointer stops moving
+ *    with an EOI at the tip, call the completion CBR ourselves. It pops the output
+ *    EDMAC FIFO (flushing EOI) and that is what dispatches the CBR we registered
+ *    as id 4. */
+static void (*TTL_StartJpCore)(void * TTL_Args) = NULL;
+static void (*TTL_JpCoreCompleteCBR)(void * TTL_Args, int size, int, int) = NULL;
+
+/* Read-only half of LockEngineResources: walks our resource ids and returns 0 if
+ * all are free, 0x1f if any is held. TTL_Prepare goes on to TakeSemaphore(sem, 0),
+ * which on DryOS means no timeout, so contention otherwise parks the task forever. */
+static int (*TTL_ResourcesBusy)(void * ResLock) = NULL;
+
+#define TTL_IS_DIGIC4       (TTL_StartJpCore != NULL)
+
+#define TTL_D4_TICK_US      500     /* how often the completion detector looks */
+#define TTL_D4_EOI_QUIET_US 500     /* unmoved this long with EOI = finished */
+#define TTL_D4_EOI_WINDOW   64
+
+/* DIGIC 4 PACK16/SNDPAS geometry. Measured on 600D LiveView Mem1->JPCORE:
+ * SNDPAS advances width+20 samples per row regardless of the pitch register, so
+ * RD1 must feed width+20 to keep rows aligned. That needs an even EDMAC row
+ * length (width+20)*14/8, which holds only for width = 4 (mod 8). The encoder
+ * also holds ~21 rows in the pipeline; 24 surplus RD1 rows flush them. */
+#define D4_GEO_PIPELINE_ROWS      24
+#define D4_GEO_PITCH_PAD          20
+#define D4_GEO_MAX_OVERREAD_ROWS  64
+
+struct d4_geometry
+{
+    int width;
+    int height;
+    int pitch;              /* SNDPAS row advance = width + pad */
+    int feed_delta;         /* RD1 supplies width+feed_delta samples per row */
+    int flush_rows;
+};
+
+static void d4_geometry_for_width(struct d4_geometry *out, int width, int height, int src_width)
+{
+    int pitch = width + D4_GEO_PITCH_PAD;
+    int feed = width + D4_GEO_PITCH_PAD;
+
+    /* Odd EDMAC row length is refused; over-long feed drives off1b negative. Fall
+     * back to the stock read: the frame shears, but it encodes. */
+    if (width <= 0 || (width & 7) != 4 || feed > src_width)
+    {
+        feed = width;
+    }
+
+    out->width = width;
+    out->height = height;
+    out->pitch = pitch;
+    out->feed_delta = feed - width;
+    out->flush_rows = D4_GEO_PIPELINE_ROWS;
+}
+
+/* Scan the last `window` bytes for FF D9. Entropy-coded data cannot contain a
+ * bare FF (stuffed as FF 00), so this marker only appears where the frame ends. */
+static unsigned int d4_lj92_eoi_end(const unsigned char *buf, unsigned int size, unsigned int window)
+{
+    unsigned int start, i;
+
+    if (!buf || size < 2)
+        return 0;
+    if (window > size)
+        window = size;
+
+    start = size - window;
+    for (i = size; i >= start + 2; i--)
+    {
+        if (buf[i - 2] == 0xFF && buf[i - 1] == 0xD9)
+            return i;
+    }
+    return 0;
+}
+
+static int d4_lj92_has_eoi(const unsigned char *buf, unsigned int size, unsigned int window)
+{
+    return d4_lj92_eoi_end(buf, size, window) != 0;
+}
+
+int lossless_input_overread_rows(void)
+{
+    return TTL_IS_DIGIC4 ? D4_GEO_MAX_OVERREAD_ROWS : 0;
+}
+
+int lossless_encodable_width(int width)
+{
+    int w;
+
+    if (!TTL_IS_DIGIC4 || width <= 0)
+        return width;
+
+    /* Nearest width = 4 (mod 8) at or below `width`, never below 4. */
+    w = width - ((width - 4) & 7);
+    if (w < 4)
+        w += 8;
+    return w;
+}
+
+static int TTL_wr1_pos(void)
+{
+    return edmac_get_pointer(TTL_Args.WR1_Channel)
+         - edmac_get_address(TTL_Args.WR1_Channel);
+}
+
+/* One-shot timer chain (~30 ticks/frame). Each encode gets a generation token a
+ * tick must still match to re-arm, so late timers from a previous frame cannot
+ * signal the next one. A plain armed flag is not enough: clearing and re-setting
+ * it inside one tick period lets the previous chain keep going. */
+static int TTL_stall_gen = 0;
+static int TTL_stall_pos = 0;
+static uint32_t TTL_stall_time = 0;
+static const unsigned char * TTL_stall_out = 0;
+
+static void TTL_stall_cbr(int last_expiry, void * priv)
+{
+    if ((int)(intptr_t) priv != TTL_stall_gen)
+        return;
+
+    uint32_t now = get_us_clock();
+    int pos = TTL_wr1_pos();
+
+    if (pos != TTL_stall_pos)
+    {
+        TTL_stall_pos = pos;
+        TTL_stall_time = now;
+    }
+    else if (pos && now - TTL_stall_time >= TTL_D4_EOI_QUIET_US
+             && d4_lj92_eoi_end(TTL_stall_out, pos, TTL_D4_EOI_WINDOW))
+    {
+        TTL_JpCoreCompleteCBR(&TTL_Args, pos, 0, 0);
+        return;
+    }
+
+    /* Quiet without EOI means starved, not done. Bound hangs with lossless_sem. */
+    SetHPTimerNextTick(last_expiry, TTL_D4_TICK_US, TTL_stall_cbr, TTL_stall_cbr, priv);
+}
+
 /* edmac-memcpy.c */
 extern uint32_t edmac_write_chan;
 extern uint32_t edmac_read_chan;
 
 static void decompress_init();
+
 int lossless_init()
 {
     if (is_camera("5D3", "1.1.3"))
@@ -184,9 +337,71 @@ int lossless_init()
         TTL_Finish      = (void *) 0xFF4384E4;  /* called next; calls UnlockEngineResources and returns output size from JpCoreCompleteCBR */
     }
 
+    if (is_camera("600D", "1.0.2"))
+    {
+        /* ProcessTwoInTwoOutJpegPath, 600D 1.0.2 (DIGIC 4)
+         *
+         * Same "TTJ" path as 650D/700D/EOSM/100D, and its JPCORE does support
+         * lossless: with SamplePrecision 0xE the path calls
+         * JPCORE_SetEncodeLosslessType(1). Canon's own caller is
+         * ProcessTwoInTwoOutJpegPath at 0xFF2FE0DC; sdfExecuteMem1ToRawPath
+         * (0xFF094CB4) drives it.
+         */
+        TTL_SetArgs     = (void *) 0xFF2155E0;  /* SetTwoInTwoOutJpegPathArgs; PictureSize 0 selects RAW */
+        TTL_Prepare     = (void *) 0xFF2FE090;  /* wraps LockEngineResources; unlike D5 it does not set up the encoder */
+        TTL_RegisterCBR = (void *) 0xFF2FD424;  /* RegisterTwoInTwoOutJpegPathCompleteCBR; ids 0, 1, 4, 5 */
+        TTL_SetFlags    = NULL;                 /* no equivalent; the picture type comes from SamplePrecision */
+        TTL_Start       = (void *) 0xFF2FDA5C;  /* configures JPCORE + EDMACs and runs the engio lists */
+        TTL_StartJpCore = (void *) 0xFF2FD784;  /* starts the encoder, then the input EDMAC */
+        TTL_Stop        = (void *) 0xFF2FD670;
+        TTL_Finish      = (void *) 0xFF2FD518;  /* UnLockEngineResources; the extra args are ignored */
+        TTL_JpCoreCompleteCBR = (void *) 0xFF2FD9C8;
+        TTL_ResourcesBusy = (void *) 0xFF1E4D40;
+    }
+
     lossless_sem = create_named_semaphore(NULL, SEM_CREATE_LOCKED);
-    
-    if (is_camera("700D", "*") || is_camera("650D", "*") || is_camera("EOSM", "*") || is_camera("100D", "*"))
+
+    if (is_camera("600D", "*"))
+    {
+        /* Canon's own list for this path, from ROM at 0xFF5FFE34 (17 entries).
+         * Write EDMAC index 4 (WR2) is left out - we never use it. */
+        uint32_t resources[] = {
+            0x00000 | edmac_channel_to_index(edmac_write_chan),
+            0x10000 | edmac_channel_to_index(edmac_read_chan),
+            0x30000,    /* Read connection 0 (uncompressed input) */
+            0x20005,    /* Write connection 5 (compressed output) */
+            0x20016,    /* Write connection 22 (for WR2 - not used) */
+            0x50003,
+            0x5000d,
+            0x5000f,
+            0x5001a,
+            0x80000,
+            0x90000,
+            0xa0000,
+            0x160000,
+            0x130003,
+            0x130004,
+            0x130005,
+        };
+
+        /* Same list without the five entries LiveView keeps. Canon can name the
+         * full set because it only runs this path with the mirror down; we cannot,
+         * because LockEngineResources has no timeout. Leaving out 0x5000d/0f/1a and
+         * 0x130004 costs no clock - sibling entries keep those classes powered.
+         * 0x80000 is the only class-8 entry, so this list depends on the display
+         * holding class 8 up, which is exactly when it gets used. */
+        uint32_t resources_shared[] = {
+            0x00000 | edmac_channel_to_index(edmac_write_chan),
+            0x10000 | edmac_channel_to_index(edmac_read_chan),
+            0x30000, 0x20005, 0x20016,
+            0x50003, 0x90000, 0xa0000, 0x160000,
+            0x130003, 0x130005,
+        };
+
+        TTL_ResLock = CreateResLockEntry(resources, COUNT(resources));
+        TTL_ResLock_shared = CreateResLockEntry(resources_shared, COUNT(resources_shared));
+    }
+    else if (is_camera("700D", "*") || is_camera("650D", "*") || is_camera("EOSM", "*") || is_camera("100D", "*"))
     {
         uint32_t resources[] = {
             0x00000 | edmac_channel_to_index(edmac_write_chan),
@@ -263,18 +478,165 @@ int lossless_init()
 
 static uint32_t start_time = 0;
 
-/* returns output size if successful, negative on error */
-int lossless_compress_raw_rectangle(
+/* PACK16 (C0F085xx) and SNDPAS (C0F0D0xx) registers LiveView owns while the
+ * display is up. Canon's RAW prepare list overwrites them; the stop list only
+ * soft-resets the block bases and never puts these back. Save from the engio
+ * shadow before Start, EngDrvOut them back after Stop while the resource lock
+ * still holds the clocks. DIGIC 4 only. */
+static const uint32_t TTL_d4_lv_regs[] = {
+    0xC0F08544, 0xC0F08548, 0xC0F08550, 0xC0F08554, 0xC0F08558,
+    0xC0F08560, 0xC0F0856C, 0xC0F08570,
+    0xC0F0D008, 0xC0F0D014, 0xC0F0D018, 0xC0F0D038,
+};
+static uint32_t TTL_d4_lv_saved[COUNT(TTL_d4_lv_regs)];
+
+static void TTL_d4_lv_save(void)
+{
+    for (int i = 0; i < COUNT(TTL_d4_lv_regs); i++)
+        TTL_d4_lv_saved[i] = shamem_read(TTL_d4_lv_regs[i]);
+}
+
+static void TTL_d4_lv_restore(void)
+{
+    for (int i = 0; i < COUNT(TTL_d4_lv_regs); i++)
+        EngDrvOut(TTL_d4_lv_regs[i], TTL_d4_lv_saved[i]);
+}
+
+/* ROM prepare list is ~97 pairs; clone enough for that plus the terminator. */
+#define TTL_D4_PREPARE_MAX_WORDS  256
+static uint32_t TTL_d4_prepare_clone[TTL_D4_PREPARE_MAX_WORDS];
+static uint32_t * TTL_d4_prepare_orig;
+
+static int TTL_d4_patch_prepare_list(const struct d4_geometry * geo)
+{
+    uint32_t * src = TTL_Args.engio_cmd_1_prepare;
+    int i = 0;
+
+    if (!src || TTL_d4_prepare_orig)
+        return 0;
+
+    while (i < TTL_D4_PREPARE_MAX_WORDS - 2 && src[i] != 0xFFFFFFFFu)
+    {
+        if ((src[i] & 0xFFF00000) != 0xC0F00000)
+            return 0;
+
+        TTL_d4_prepare_clone[i] = src[i];
+        TTL_d4_prepare_clone[i + 1] = src[i + 1];
+
+        switch (src[i])
+        {
+            case 0xC0F0858C:
+                TTL_d4_prepare_clone[i + 1] = (unsigned int) geo->width;
+                break;
+            case 0xC0F08594:
+                TTL_d4_prepare_clone[i + 1] = (unsigned int) (geo->pitch - 2);
+                break;
+            case 0xC0F0D01C:
+            case 0xC0F0D024:
+                TTL_d4_prepare_clone[i + 1] = (unsigned int) geo->pitch;
+                break;
+            case 0xC0F0D020:
+                TTL_d4_prepare_clone[i + 1] = (unsigned int) (geo->pitch + 3);
+                break;
+            default:
+                break;
+        }
+
+        i += 2;
+    }
+
+    if (i >= TTL_D4_PREPARE_MAX_WORDS - 1)
+        return 0;
+
+    TTL_d4_prepare_clone[i] = 0xFFFFFFFFu;
+    TTL_d4_prepare_orig = src;
+    TTL_Args.engio_cmd_1_prepare = TTL_d4_prepare_clone;
+    return 1;
+}
+
+static void TTL_d4_restore_prepare_list(void)
+{
+    if (TTL_d4_prepare_orig)
+    {
+        TTL_Args.engio_cmd_1_prepare = TTL_d4_prepare_orig;
+        TTL_d4_prepare_orig = 0;
+    }
+}
+
+static void TTL_d4_apply_geometry(const struct d4_geometry * geo)
+{
+    EngDrvOut(0xC0F0858C, (unsigned int) geo->width);
+    EngDrvOut(0xC0F08594, (unsigned int) (geo->pitch - 2));
+    EngDrvOut(0xC0F0D01C, (unsigned int) geo->pitch);
+    EngDrvOut(0xC0F0D020, (unsigned int) (geo->pitch + 3));
+    EngDrvOut(0xC0F0D024, (unsigned int) geo->pitch);
+}
+
+/* OBWB per-Bayer gain. Unity is 0x400 (Q10). The field is 11 bits; values past
+ * 0x7FF alias to gain 0 and collapse the frame to the pedestal. The encoder
+ * input stage subtracts the optical black, applies this gain and re-pedestals
+ * at 512 - that is also how reduced bit depths are reached (attenuate here
+ * instead of via SHAD_GAIN, which never reaches the DIGIC 4 raw slurp). */
+#define TTL_D4_OBWB_UNITY     0x400
+#define TTL_D4_OBWB_PEDESTAL  512
+
+static const uint32_t TTL_d4_obwb_gain_regs[] = {
+    0xC0F0E084,     /* phase (0,0) */
+    0xC0F0E074,     /* phase (0,1) */
+    0xC0F0E064,     /* phase (1,0) */
+    0xC0F0E054,     /* phase (1,1) */
+};
+
+static int TTL_d4_target_bpp = 14;
+
+void lossless_d4_set_target_bpp(int bpp)
+{
+    TTL_d4_target_bpp = COERCE(bpp, 8, 14);
+}
+
+static uint32_t TTL_d4_obwb_gain(void)
+{
+    return TTL_D4_OBWB_UNITY >> (14 - TTL_d4_target_bpp);
+}
+
+int lossless_d4_map_level(int level, int black_in)
+{
+    int mapped;
+
+    if (!TTL_IS_DIGIC4)
+        return level;
+
+    mapped = (level - black_in) * (int) TTL_d4_obwb_gain()
+             / TTL_D4_OBWB_UNITY + TTL_D4_OBWB_PEDESTAL;
+    return COERCE(mapped, 0, 16383);
+}
+
+static void TTL_d4_obwb_apply(void)
+{
+    uint32_t value = TTL_d4_obwb_gain();
+    int i;
+
+    for (i = 0; i < (int) COUNT(TTL_d4_obwb_gain_regs); i++)
+        EngDrvOut(TTL_d4_obwb_gain_regs[i], value);
+}
+
+/* returns output size if successful, negative on error:
+ * -1 not initialised, -2 encoder timeout, -3 output is not a JPEG,
+ * -4 engine resources busy, -5 Prepare failed,
+ * -7 positive size without a terminal EOI (incomplete LJ92) */
+static int lossless_compress_raw_rectangle_once(
     struct memSuite * dst_suite, void * src,
     int src_width, int src_x, int src_y,
     int width, int height
 )
 {
+    struct d4_geometry geo;
+
     if (!TTL_ResLock || !lossless_sem || !TTL_Start)
-    {
-        /* not initialized */
         return -1;
-    }
+
+    d4_geometry_for_width(&geo, width, height, src_width);
+    width = geo.width;
 
     /* setup photo quality (valid values: 0=RAW, 1=MRAW, 2=SRAW, 14, 15) */
     TTL_SetArgs(0, &TTL_Args, 0);
@@ -305,8 +667,12 @@ int lossless_compress_raw_rectangle(
 
     /* to check whether the compression was successful */
     /* note: in dummy mode, dst_suite is NULL - don't check this case */
+    /* Every use of WR1_Address is a CPU access to a buffer the WR1 EDMAC writes.
+     * MLV Lite's slots come off the memory suite without UNCACHEABLE(), so take
+     * the uncacheable alias here - otherwise a dirty cache line can be written
+     * back over the finished JPEG, and the SOI/EOI checks can read stale data. */
     void * WR1_Address = (TTL_Args.WR1_MemSuite)
-        ? GetMemoryAddressOfMemoryChunk(GetFirstChunkFromSuite(TTL_Args.WR1_MemSuite))
+        ? UNCACHEABLE(GetMemoryAddressOfMemoryChunk(GetFirstChunkFromSuite(TTL_Args.WR1_MemSuite)))
         : 0;
 
     if (WR1_Address)
@@ -314,8 +680,57 @@ int lossless_compress_raw_rectangle(
         MEM(WR1_Address) = 0;
     }
 
-    /* configure the processing modules */
-    TTL_Prepare(TTL_ResLock, &TTL_Args);
+    /* Prefer Canon's full resource list (locking also powers the blocks up);
+     * fall back to the LiveView-safe shared list when the full one is held.
+     * Short same-frame retries absorb transient LV ownership. */
+    struct LockEntry * lock = TTL_ResLock;
+    int lock_retries = 0;
+
+    if (TTL_ResourcesBusy)
+    {
+        const int max_retries = TTL_IS_DIGIC4 ? 8 : 0;
+        while (1)
+        {
+            lock = TTL_ResLock;
+            if (!TTL_ResourcesBusy(lock))
+                break;
+
+            lock = TTL_ResLock_shared;
+            if (lock && !TTL_ResourcesBusy(lock))
+                break;
+
+            if (lock_retries >= max_retries)
+                return -4;
+
+            lock_retries++;
+            msleep(1);
+        }
+    }
+
+    /* Patch Canon's prepare list before Start latches companions that post-Start
+     * EngDrvOut cannot move. Reinforced after Start by TTL_d4_apply_geometry. */
+    if (TTL_IS_DIGIC4)
+        TTL_d4_patch_prepare_list(&geo);
+
+    int prepared = TTL_Prepare(lock, &TTL_Args);
+
+    /* On DIGIC 4 the status is LockEngineResources' own; odd means the engine
+     * clocks were never switched on. Nothing to Finish either - Canon does not
+     * call it on this path. */
+    if (TTL_IS_DIGIC4 && (prepared & 1))
+    {
+        TTL_d4_restore_prepare_list();
+        return -5;
+    }
+
+    if (TTL_IS_DIGIC4)
+    {
+        TTL_d4_lv_save();
+        TTL_Start(&TTL_Args);
+        TTL_d4_restore_prepare_list();
+        TTL_d4_apply_geometry(&geo);
+        TTL_d4_obwb_apply();
+    }
 
     if (is_camera("6D", "*") ||
         is_camera("650D", "*"))
@@ -341,6 +756,14 @@ int lossless_compress_raw_rectangle(
         EngDrvOut(0xC0F37300, PACK32(width    - 1,  height/2  - 1));  /* 0xE7B0ADF on 70D */
         EngDrvOut(0xC0F373E8, PACK32(width    - 1,  height/2  - 1));  /* 0xE7B0ADF on 70D */
     }
+    else if (TTL_IS_DIGIC4)
+    {
+        /* no 0xC0F375B4 on this generation; the slice geometry lives in 0xC0F120xx.
+         * Canon's RAW list (0xFF5FFE78 on the 600D) writes 3 slices of 1728x3456 for the
+         * 5184x3456 sensor frame; transpose that the way the DIGIC 5 branch does and leave
+         * the slice count alone. */
+        EngDrvOut(0xC0F12010, PACK32(width - 1,  height/3  - 1));
+    }
     else if (is_camera("DIGIC", "5"))
     {
         /* all other D5 models use this register instead */
@@ -351,7 +774,7 @@ int lossless_compress_raw_rectangle(
         EngDrvOut(0xC0F375B4, PACK32(width    - 1,  height/2  - 1));  /* 0xF6D0B8F on 5D3 */
     }
 
-    if (is_camera("DIGIC", "5"))
+    if (is_camera("DIGIC", "5") || TTL_IS_DIGIC4)
     {
         /* required for full-res silent pictures? */
         /* this one doesn't seem to refer to slice size, but to total image size */
@@ -381,10 +804,12 @@ int lossless_compress_raw_rectangle(
      * 
      * => the input EDMAC will simply read the image as usual.
      */
+    int feed_width = width + geo.feed_delta;
+
     struct edmac_info RD1_info = {
-        .xb     = width * 14/8,
-        .yb     = height - 1,
-        .off1b  = src_width * 14/8 - width * 14/8,
+        .xb     = feed_width * 14/8,
+        .yb     = height + (TTL_IS_DIGIC4 ? geo.flush_rows : 0) - 1,
+        .off1b  = src_width * 14/8 - feed_width * 14/8,
     };
 
     SetEDmac(TTL_Args.RD1_Channel, TTL_Args.RD1_Address, &RD1_info, TTL_Args.RD1_Flags);
@@ -402,17 +827,47 @@ int lossless_compress_raw_rectangle(
     /* register our CBR, to be called when finished */
     TTL_RegisterCBR(4, LosslessCompleteCBR, 0);
     
-    /* this changes a few registers that appear to be bit fields */
-    TTL_SetFlags(0x10000);
+    if (TTL_SetFlags)
+    {
+        /* this changes a few registers that appear to be bit fields */
+        TTL_SetFlags(0x10000);
+    }
 
     /* time the operation */
     start_time = get_us_clock();
 
-    /* this starts the EDmac channels */
-    TTL_Start(&TTL_Args);
+    if (TTL_IS_DIGIC4)
+    {
+        /* Arm before the encoder runs so the first tick cannot mistake an
+         * output that has not started moving for one that has stopped. */
+        TTL_stall_pos = 0;
+        TTL_stall_time = start_time;
+        TTL_stall_out = (const unsigned char *) WR1_Address;
+        SetHPTimerAfterNow(TTL_D4_TICK_US, TTL_stall_cbr, TTL_stall_cbr,
+                           (void *)(intptr_t) ++TTL_stall_gen);
+    }
 
-    /* wait until finished */
-    int err = take_semaphore(lossless_sem, 1000);
+    /* this starts the EDmac channels; on DIGIC 4 the configuring half already ran */
+    (TTL_IS_DIGIC4 ? TTL_StartJpCore : TTL_Start)(&TTL_Args);
+
+    /* wait until finished. DIGIC 4 encodes in ~15 ms and the caller runs once
+     * per LiveView frame even when idle, so a stuck encode must not cost a second. */
+    int err = take_semaphore(lossless_sem, TTL_IS_DIGIC4 ? 100 : 1000);
+
+    /* retire the detector; on timeout it is still ticking */
+    TTL_stall_gen++;
+
+    if (TTL_IS_DIGIC4 && err)
+    {
+        /* detector may have completed just as we gave up; drain that or it
+         * would satisfy the next frame's wait before its encoder wrote anything */
+        take_semaphore(lossless_sem, 1);
+    }
+
+    /* DIGIC 4 reports size nowhere: Finish only unlocks, and the completion CBR
+     * publishes the pointer from just before the pop. Read WR1 while the channel
+     * is still programmed. */
+    uint32_t output_size = (TTL_IS_DIGIC4 && !err) ? TTL_wr1_pos() : 0;
 
     if (verbose >= 2)
     {
@@ -420,32 +875,69 @@ int lossless_compress_raw_rectangle(
         printf("[TTL] Elapsed time: %d us\n", (int)(stop_time - start_time));
     }
 
-    /* stop processing; this will report output size */
-    uint32_t output_size = 0;
+    /* stop processing; this will report output size (DIGIC 4 leaves it alone) */
     TTL_Stop(&TTL_Args);
-    TTL_Finish(TTL_ResLock, &TTL_Args, &output_size);
+
+    if (TTL_IS_DIGIC4)
+        TTL_d4_lv_restore();
+
+    TTL_Finish(lock, &TTL_Args, &output_size);
+
+    /* Prepare-list pointer is restored after Start on the success path; keep the
+     * restore here so early returns after a patched Prepare cannot leak it. */
+    if (TTL_IS_DIGIC4)
+        TTL_d4_restore_prepare_list();
 
     if (verbose >= 1)
     {
-        /* compute input size (uncompressed) */
-        uint32_t input_size = RD1_info.xb * (RD1_info.yb + 1);
+        /* compute input size (uncompressed); the flush rows are not part of the picture */
+        uint32_t input_size = RD1_info.xb * height;
 
         int ratio_x100 = output_size * 10000.0 / input_size;
         printf("[TTL] Output size : %s (%s%d.%02d%%)\n", format_memory_size(output_size), FMT_FIXEDPOINT2(ratio_x100));
     }
 
     if (err)
-    {
         return -2;
-    }
 
     /* do we have valid JPEG data in the output buffer? */
     if (WR1_Address && MEM(WR1_Address) != 0xC4FFD8FF)
-    {
         return -3;
-    }
+
+    /* Positive size without a terminal EOI is an incomplete frame. */
+    if (TTL_IS_DIGIC4 && WR1_Address && output_size > 0
+        && !d4_lj92_has_eoi((const unsigned char *) WR1_Address, output_size,
+                            TTL_D4_EOI_WINDOW))
+        return -7;
+
+    /* Zero size with SOI in place is the same aborted encode as -3; MLV Lite
+     * only rejects negatives, so a 0 would become a 0-byte VIDF. */
+    if (TTL_IS_DIGIC4 && WR1_Address && output_size <= 0)
+        return -3;
 
     return output_size;
+}
+
+int lossless_compress_raw_rectangle(
+    struct memSuite * dst_suite, void * src,
+    int src_width, int src_x, int src_y,
+    int width, int height
+)
+{
+    int res = lossless_compress_raw_rectangle_once(
+        dst_suite, src, src_width, src_x, src_y, width, height);
+
+    /* Transient aborts (SOI written, size 0) are usually LiveView holding the
+     * resources for one frame, not a bad image. Retry once: double buffering
+     * leaves the source intact for ~80 ms and one encode is ~15 ms. A systematic
+     * failure fails again and stops the clip as before. */
+    if (res == -3 && TTL_IS_DIGIC4)
+    {
+        res = lossless_compress_raw_rectangle_once(
+            dst_suite, src, src_width, src_x, src_y, width, height);
+    }
+
+    return res;
 }
 
 int lossless_compress_raw(struct raw_info * raw_info, struct memSuite * output_memsuite)
@@ -456,7 +948,6 @@ int lossless_compress_raw(struct raw_info * raw_info, struct memSuite * output_m
         raw_info->width, raw_info->height
     );
 }
-
 
 /* decompression stuff wizardry goes here */
 struct DecodeLossless_args

--- a/modules/silent/lossless.h
+++ b/modules/silent/lossless.h
@@ -17,11 +17,30 @@ int lossless_compress_raw_rectangle(
     int width, int height
 );
 
+/* Rows the input EDMAC reads past the bottom of the rectangle, to push the last
+ * real ones through the DIGIC 4 pipeline ahead of the encoder. Zero elsewhere.
+ * Callers that own the source buffer must keep that much readable after it. */
+int lossless_input_overread_rows(void);
+
+/* Largest width at or below `width` the encoder can render without shear.
+ * Identity except on DIGIC 4, which needs width = 4 (mod 8) so the RD1 row
+ * length that cancels the SNDPAS advance is a whole even byte count. */
+int lossless_encodable_width(int width);
+
+/* Map a LiveView 14-bit level onto the level the encoder emits, for RAWI
+ * metadata. Identity except on DIGIC 4, whose input stage subtracts the optical
+ * black, applies a per-Bayer gain and re-pedestals, so levels move affinely.
+ * `black_in` is the LiveView black the mapping is measured against. */
+int lossless_d4_map_level(int level, int black_in);
+
+/* Bit depth the encode should attenuate to, 8..14. Only meaningful on DIGIC 4,
+ * where reduced depths are reached through the encoder's OBWB gain stage. */
+void lossless_d4_set_target_bpp(int bpp);
+
 int lossless_decompress_raw(
     struct memSuite * src, void * dst,
     int width, int height,
     int output_bpp
 );
-
 
 #endif

--- a/platform/Makefile
+++ b/platform/Makefile
@@ -380,6 +380,7 @@ ML_SRC_OBJS_00 = \
     chdk-dng.o \
     edmac-memcpy.o \
     sd.o \
+    sd_overclock.o \
     cache_hacks.o \
     patch.o \
     picstyle.o \

--- a/src/raw.c
+++ b/src/raw.c
@@ -2137,8 +2137,15 @@ void FAST raw_lv_vsync()
         if (lv_raw_gain)
         {
             /* optional - adjust digital gain */
-            /* fixme: hardcoded for 5D3 */
+            /* The raw type override is a DIGIC 5 value. On DIGIC 4
+             * RAW_TYPE_REGISTER is PACK32_ISEL, where the CCD selector is 0x5
+             * (PREFERRED_RAW_TYPE) and 0x12 picks a different input entirely -
+             * the same register mlv_lite zeroes to fix the pink preview. Writing
+             * it here also fought the lv_raw_type write just above, every frame.
+             * So leave the type alone on DIGIC 4 and only set the gain. */
+            #ifndef CONFIG_DIGIC_IV
             EngDrvOut(RAW_TYPE_REGISTER, 0x12);
+            #endif
             EngDrvOut(SHAD_GAIN_REGISTER, lv_raw_gain);
         }
 
@@ -2163,12 +2170,19 @@ void FAST raw_lv_vsync()
 /* this gain must not (!) change the raw data */
 int _raw_lv_get_iso_post_gain()
 {
+#ifdef CONFIG_DIGIC_IV
+    /* On DIGIC 4 the ISO boost that accompanies digital gain does change the
+     * raw data, so there is nothing to correct in metadata. Returning the D5
+     * reciprocal made 12-bit clips ~4x too bright and 11-bit ~8x. */
+    return 1;
+#else
     if (lv_raw_gain)
     {
         return 4096 / lv_raw_gain;
     }
 
     return 1;
+#endif
 }
 
 #endif // CONFIG_EDMAC_RAW_SLURP

--- a/src/sd_overclock.c
+++ b/src/sd_overclock.c
@@ -1,0 +1,387 @@
+/* SDHC Overclock for DIGIC 4 SD bodies
+ *
+ * Raises the SD bus clock above Canon's 48 MHz High-Speed setting by
+ * reprogramming PLL1, the SD root clock.
+ *
+ * Principle of operation
+ * ----------------------
+ * The SD bus is clocked from PLL1 at 0xC04000BC.  Sweeping that register
+ * moved card throughput 1.65x (N=5 -> N=6) while an RTC-referenced timer
+ * rate and a DRAM memcpy control stayed flat, so PLL1 is the SD root and
+ * not a system or CPU clock.
+ *
+ * The word is a 16.16 fixed-point divider:
+ *
+ *     word = 0x3CFC8 + k * 0x1000
+ *     f    = 1152 / k  MHz        (at the undivided mux setting)
+ *     stock k = 24 -> 48.0 MHz
+ *
+ * CLK_SEL[25:24] at 0xC0400004 is a post-divider of (4 - mode).  Mode 3 is
+ * Canon's undivided High-Speed setting.  Mode 0 is a fixed ~200 kHz
+ * identification clock independent of PLL1, which is why raising the root
+ * does not disturb card init.
+ *
+ * Valid-word rule (fatal if broken)
+ * ---------------------------------
+ * Only words from the table below are safe.  Two bit constraints, both
+ * learned by hard hang:
+ *
+ *   bits [11:0] must stay 0xFC8
+ *   bits [13:12] must be 00
+ *
+ * Together they mean k must be a multiple of 4, so the only reachable
+ * roots are 288/m MHz.  There is nothing between 96 and 144.  An off-grid
+ * word (e.g. 0x0004BFC8, k=15) hard hung the camera: screen off, no
+ * button response, battery pull.  Never compute a word at runtime.
+ *
+ * Measured on 600D 1.0.2 (16 MB file, 2 MB chunks, interleaved):
+ *   48 MHz  read 755 ms / write 802 ms
+ *   96 MHz  read 397 ms / write 384 ms   (1.90x / 2.08x, byte-exact)
+ *   144 MHz wedged the SD driver on the tested card (UI still alive)
+ *
+ * Apply sequence
+ * --------------
+ * Canon's sd_set_bus_clock_mode has no status-bit polling: it gates
+ * CLOCK_ENABLE bit 28 off, writes CLK_SEL[25:24], gates back on, with a
+ * ~1 ms delay on each side.  DAT at 0xFF4FAB54 reads 0xC0400000, so the
+ * base is fixed hardware and the sequence can be reproduced in C with no
+ * ROM address - which is what makes this portable across DIGIC 4 SD
+ * bodies.  The PLL write is folded inside the gated window; changing the
+ * root while the clock is live is what hung early probe attempts.
+ *
+ * Canon's own routine leaves the gate OFF and kills the interface if
+ * called with mode > 3; the mux value here is therefore a constant, not
+ * a parameter.
+ */
+
+#include "dryos.h"
+#include "menu.h"
+#include "config.h"
+#include "notify_box.h"
+
+#if defined(CONFIG_DIGIC_IV) && !defined(CONFIG_CF_SLOT)
+
+/* ---------------------------------------------------------------------------
+ * Register map (DIGIC 4 SD clock block at 0xC0400000)
+ * ------------------------------------------------------------------------- */
+
+#define SDCLK_REG_CLK_SEL     0xC0400004   /* [25:24] bus clock mux, div = 4 - mode */
+#define SDCLK_REG_CLOCK_EN    0xC0400008   /* bit 28 gates the SD interface clock */
+#define SDCLK_REG_PLL1_WORD   0xC04000BC   /* SD root PLL, 16.16 divider word */
+
+#define SDCLK_GATE_BIT        (1u << 28)
+#define SDCLK_MUX_SHIFT       24
+#define SDCLK_MUX_MASK        (3u << SDCLK_MUX_SHIFT)
+#define SDCLK_MUX_UNDIVIDED   3            /* div = 1; Canon's own maximum */
+
+#define SDCLK_WORD_BASE       0x0003CFC8u  /* word = BASE + k * 0x1000 */
+#define SDCLK_WORD_STOCK      0x00054FC8u  /* k = 24 -> 48.0 MHz */
+
+/* Scratch file for the post-apply write/read verification. */
+#define SDCLK_VERIFY_FILE     "ML/SDOCLK.TMP"
+#define SDCLK_VERIFY_SIZE     512
+
+/* Dirty-flag basename under get_config_dir(); armed only above MAX_VERIFIED. */
+#define SDCLK_FLAG_NAME       "SDOCLK.TRY"
+
+/* ---------------------------------------------------------------------------
+ * Frequency table
+ *
+ * Valid words obey two constraints, both learned the hard way:
+ *   bits [11:0] must stay 0xFC8 - the four words that changed them got slower,
+ *                                 never faster, and then wedged;
+ *   bits [13:12] must be 00     - 0x0004BFC8 has 0b11 there and hard hung the
+ *                                 camera: screen off, no button response,
+ *                                 battery pull.  A malformed divider output
+ *                                 takes the whole system down, not just the
+ *                                 card, so a bad word is unrecoverable and no
+ *                                 software guard can help.  Never compute a
+ *                                 word at runtime; only pick from this table.
+ * Together they mean k must be a multiple of 4, so the only reachable roots are
+ * 288/m MHz.  There is nothing between 96 and 144.
+ * ------------------------------------------------------------------------- */
+
+struct sdclk_setting {
+    uint32_t word;      /* 0xC04000BC value */
+    int16_t  k;         /* divider in sixteenths; f = 1152/k MHz */
+    int16_t  mhz10;     /* bus clock in tenths of MHz, at mux 3 */
+    const char * name;
+};
+
+static const struct sdclk_setting sdclk_settings[] = {
+    { 0x00054FC8u, 24,  480, "48 MHz (stock)"   },
+    { 0x0004CFC8u, 16,  720, "72 MHz"           },
+    { 0x00048FC8u, 12,  960, "96 MHz"           },
+    { 0x00044FC8u,  8, 1440, "144 MHz DANGER"   },
+};
+
+#define SDCLK_IDX_STOCK        0
+#define SDCLK_IDX_MAX_VERIFIED 2   /* 96 MHz; anything past this arms the flag */
+
+/* Persisted menu index.  Default 0 = stock. */
+static CONFIG_INT("sd.overclock", sd_overclock_idx, 0);
+
+/* Latched at INIT_FUNC, before anything writes PLL1.  Every number in the
+ * table is calibrated against SDCLK_WORD_STOCK; a different reset default
+ * means different silicon and the feature disables itself. */
+static uint32_t sdclk_pll1_at_init = 0;
+static int sdclk_calibrated = 0;
+
+/* ---------------------------------------------------------------------------
+ * Apply / decode
+ * ------------------------------------------------------------------------- */
+
+/* Faithful reproduction of Canon's sd_set_bus_clock_mode with the PLL word
+ * write folded inside the gated window.  Mux is a constant (see file header). */
+static void sdclk_apply(uint32_t word)
+{
+    uint32_t irq = cli();
+    MEM(SDCLK_REG_CLOCK_EN) &= ~SDCLK_GATE_BIT;
+    sei(irq);
+    msleep(1);
+
+    irq = cli();
+    MEM(SDCLK_REG_PLL1_WORD) = word;
+    (void)MEM(SDCLK_REG_PLL1_WORD);
+    MEM(SDCLK_REG_CLK_SEL) = (MEM(SDCLK_REG_CLK_SEL) & ~SDCLK_MUX_MASK)
+                           | (SDCLK_MUX_UNDIVIDED << SDCLK_MUX_SHIFT);
+    MEM(SDCLK_REG_CLOCK_EN) |=  SDCLK_GATE_BIT;
+    sei(irq);
+    msleep(2);
+}
+
+/* Decode a live PLL1 word to tenths of MHz.  Returns 0 if the word is not
+ * on the 0x1000 grid from SDCLK_WORD_BASE (and therefore not one of ours). */
+static int sdclk_mhz10_from_word(uint32_t word)
+{
+    if (word < SDCLK_WORD_BASE)
+        return 0;
+    uint32_t delta = word - SDCLK_WORD_BASE;
+    if (delta % 0x1000u)
+        return 0;
+    int k = (int)(delta / 0x1000u);
+    if (k <= 0)
+        return 0;
+    return 11520 / k;
+}
+
+static int sdclk_index_of_word(uint32_t word)
+{
+    for (int i = 0; i < COUNT(sdclk_settings); i++)
+        if (sdclk_settings[i].word == word)
+            return i;
+    return -1;
+}
+
+static void sdclk_flag_path(char *buf, size_t size)
+{
+    snprintf(buf, size, "%s%s", get_config_dir(), SDCLK_FLAG_NAME);
+}
+
+/* ---------------------------------------------------------------------------
+ * Post-apply verification: write then read back a 512-byte pattern.
+ * Exercises both directions at the new clock; cannot pass on cached data.
+ * ------------------------------------------------------------------------- */
+
+static inline uint8_t sdclk_pattern_byte(int i)
+{
+    return (uint8_t)((i * 17) ^ 0xA5);
+}
+
+/* buf must be SDCLK_VERIFY_SIZE bytes from fio_malloc: card I/O wants DMA-able
+ * memory, and a buffer this size has no business on a task stack.  An earlier
+ * revision used two 512-byte stack arrays, which gave this function a 1152-byte
+ * frame inside a task created with a 1024-byte stack - it ran off the end of the
+ * stack on every boot and corrupted the heap behind it. */
+static int sdclk_verify(void *buf)
+{
+    uint8_t *p = (uint8_t *)UNCACHEABLE(buf);
+
+    for (int i = 0; i < SDCLK_VERIFY_SIZE; i++)
+        p[i] = sdclk_pattern_byte(i);
+
+    FIO_RemoveFile(SDCLK_VERIFY_FILE);
+
+    FILE *f = FIO_CreateFile(SDCLK_VERIFY_FILE);
+    if (!f)
+        return 0;
+    int w = FIO_WriteFile(f, p, SDCLK_VERIFY_SIZE);
+    FIO_CloseFile(f);
+    if (w != SDCLK_VERIFY_SIZE)
+    {
+        FIO_RemoveFile(SDCLK_VERIFY_FILE);
+        return 0;
+    }
+
+    f = FIO_OpenFile(SDCLK_VERIFY_FILE, O_RDONLY | O_SYNC);
+    if (!f)
+    {
+        FIO_RemoveFile(SDCLK_VERIFY_FILE);
+        return 0;
+    }
+    memset(p, 0, SDCLK_VERIFY_SIZE);
+    int r = FIO_ReadFile(f, p, SDCLK_VERIFY_SIZE);
+    FIO_CloseFile(f);
+    FIO_RemoveFile(SDCLK_VERIFY_FILE);
+
+    if (r != SDCLK_VERIFY_SIZE)
+        return 0;
+
+    /* Compare against the generator rather than a second buffer, so the
+     * read-back costs no extra memory. */
+    for (int i = 0; i < SDCLK_VERIFY_SIZE; i++)
+        if (p[i] != sdclk_pattern_byte(i))
+            return 0;
+    return 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * Menu
+ * ------------------------------------------------------------------------- */
+
+static MENU_UPDATE_FUNC(sd_overclock_update)
+{
+    uint32_t live = MEM(SDCLK_REG_PLL1_WORD);
+    int mhz10 = sdclk_mhz10_from_word(live);
+    int live_idx = sdclk_index_of_word(live);
+
+    if (mhz10)
+        MENU_SET_RINFO("now %d.%d", mhz10 / 10, mhz10 % 10);
+    else
+        MENU_SET_RINFO("now ?");
+
+    if (!sdclk_calibrated)
+    {
+        MENU_SET_WARNING(MENU_WARN_NOT_WORKING,
+            "PLL1 was %x, need %x - feature disabled.",
+            sdclk_pll1_at_init, SDCLK_WORD_STOCK);
+        return;
+    }
+
+    if (sd_overclock_idx > SDCLK_IDX_MAX_VERIFIED)
+    {
+        MENU_SET_WARNING(MENU_WARN_ADVICE,
+            "144 MHz wedged the SD driver on the tested card.");
+    }
+
+    if (live_idx != sd_overclock_idx)
+    {
+        MENU_SET_WARNING(MENU_WARN_ADVICE,
+            "Restart the camera to apply.");
+    }
+}
+
+static struct menu_entry sd_overclock_menu[] = {
+    {
+        .name    = "SDHC Overclock",
+        .priv    = &sd_overclock_idx,
+        .max     = COUNT(sdclk_settings) - 1,
+        .choices = CHOICES("48 MHz (stock)", "72 MHz", "96 MHz", "144 MHz DANGER"),
+        .update  = sd_overclock_update,
+        .help    = "SD bus clock. Applied at boot; restart to take effect.",
+        .help2   = "48 MHz: Canon's setting.\n"
+                   "72 MHz: 1.45x read. Verified.\n"
+                   "96 MHz: 1.90x read, 2.08x write. Verified.\n"
+                   "144 MHz: wedged the SD driver on the tested card.\n",
+    }
+};
+
+/* ---------------------------------------------------------------------------
+ * Boot: INIT_FUNC latches the guard; TASK applies after config_load
+ * ------------------------------------------------------------------------- */
+
+static void sd_overclock_init(void *unused)
+{
+    (void)unused;
+    /* Sample PLL1 before any ML code writes it.  The task (and the menu
+     * update) both consult this latch; if it is not stock the feature is
+     * inert on this body. */
+    sdclk_pll1_at_init = MEM(SDCLK_REG_PLL1_WORD);
+    sdclk_calibrated = (sdclk_pll1_at_init == SDCLK_WORD_STOCK);
+
+    menu_add("Debug", sd_overclock_menu, COUNT(sd_overclock_menu));
+}
+
+static void sd_overclock_task(void *unused)
+{
+    (void)unused;
+    /* Same delay as FEATURE_SD_AUTOTUNE in sd.c: do not touch the SD clock
+     * while DryOS is still configuring the card.  That hangs. */
+    msleep(1500);
+
+    if (!sdclk_calibrated)
+        return;
+
+    struct card_info *card = get_ml_card();
+    if (!card || !card->type || !streq(card->type, "SD"))
+        return;
+
+    /* Clamp a corrupted config value rather than indexing off the table. */
+    if (sd_overclock_idx < 0 || sd_overclock_idx >= COUNT(sdclk_settings))
+        sd_overclock_idx = SDCLK_IDX_STOCK;
+
+    char flag[0x80];
+    sdclk_flag_path(flag, sizeof(flag));
+
+    /* Previous boot armed the flag and never cleared it - that attempt
+     * wedged.  Refuse, reset to stock, and clear the flag so the next boot
+     * is clean. */
+    if (config_flag_file_setting_load(flag))
+    {
+        sd_overclock_idx = SDCLK_IDX_STOCK;
+        config_flag_file_setting_save(flag, 0);
+        config_save();
+        NotifyBox(5000, "SDHC Overclock: previous attempt failed.\n"
+                        "Reset to 48 MHz (stock).");
+        return;
+    }
+
+    if (sd_overclock_idx == SDCLK_IDX_STOCK)
+        return;
+
+    /* Get the verification buffer before touching the clock: if there is no
+     * memory to verify with there is no way to tell a working overclock from a
+     * broken one, so the clock is left alone entirely. */
+    void *buf = fio_malloc(SDCLK_VERIFY_SIZE);
+    if (!buf)
+        return;
+
+    /* Arm the flag only for unverified rungs.  Verified 72/96 MHz pay no
+     * per-boot file write; if a verified rung somehow wedges there is no
+     * auto-recovery, which is the trade-off accepted for those settings. */
+    if (sd_overclock_idx > SDCLK_IDX_MAX_VERIFIED)
+        config_flag_file_setting_save(flag, 1);
+
+    sdclk_apply(sdclk_settings[sd_overclock_idx].word);
+
+    int ok = sdclk_verify(buf);
+    fio_free(buf);
+
+    if (ok)
+    {
+        if (sd_overclock_idx > SDCLK_IDX_MAX_VERIFIED)
+            config_flag_file_setting_save(flag, 0);
+        return;
+    }
+
+    /* Verification failed: put the clock back, clear the setting so it
+     * does not retry every boot, and clear any flag we just armed. */
+    sdclk_apply(SDCLK_WORD_STOCK);
+    sd_overclock_idx = SDCLK_IDX_STOCK;
+    config_flag_file_setting_save(flag, 0);
+    config_save();
+    NotifyBox(5000, "SDHC Overclock: verify failed.\n"
+                    "Reset to 48 MHz (stock).");
+}
+
+INIT_FUNC("sd_oc", sd_overclock_init);
+
+/* 0x1000 stack, the size every ML task that calls into snprintf and FIO uses.
+ * The 0x400 that sd.c gets away with is only enough for a task whose body is a
+ * single ROM call; this one builds a path and does file I/O.  GCC reserves the
+ * whole frame at entry, so an undersized stack here overflows on every boot
+ * regardless of which branch runs, and DryOS task stacks come off the heap -
+ * the symptom is malloc failures in unrelated code. */
+TASK_CREATE("sd_oc", sd_overclock_task, 0, 0x1e, 0x1000);
+
+#endif /* CONFIG_DIGIC_IV && !CONFIG_CF_SLOT */

--- a/src/state-object.c
+++ b/src/state-object.c
@@ -166,7 +166,24 @@ static int FAST stateobj_lv_spy(struct state_object * self, int x, int input, in
     if (self == EVF_STATE && input == 5 && old_state == 5) // evfReadOutDoneInterrupt
         _lv_vsync_signal();
 #elif defined(CONFIG_600D)
-    if (self == EVF_STATE && old_state == 5) {  
+    if (self == EVF_STATE && old_state == 5) {
+        /* Borrowing JPCORE for lossless encoding makes every LiveView frame
+         * report an EngineError (EvfState +0x28). Untouched Evf never sets a
+         * single bit here, so this is inert until something steals the core;
+         * then, without a trim, 32 consecutive errors hit EvfState.c:1190 and
+         * ASSERT the camera in about a second. Trim once 20 of 32 bits are set,
+         * keeping the low half so the recent pattern stays readable. */
+        if ((uint32_t) x >= 0x10000 && (uint32_t) x < 0x20000000)
+        {
+            volatile uint32_t * hist = (volatile uint32_t *)((uint32_t) x + 0x28);
+            uint32_t v = *hist;
+            uint32_t c = v - ((v >> 1) & 0x55555555);
+            c = (c & 0x33333333) + ((c >> 2) & 0x33333333);
+            c = (c + (c >> 4)) & 0x0F0F0F0F;
+            c = (c * 0x01010101) >> 24;
+            if ((int) c >= 20)
+                *hist = v & 0x0000FFFF;
+        }
         //600D Goes 3 - 4 - 5 5 and 3 ever 1/2 frame
         _lv_vsync_signal();
     }


### PR DESCRIPTION
> ℹ️ This PR is building on top of #291 

This enables Canon's Mem1 -> JPCORE lossless path on the 600D so `mlv_lite` can record **14-bit / 12-bit / 8..11-bit lossless**, plus an optional low-FPS soft preview while JPCORE freezes Evf.

Split into two commits so soft preview can be reverted independently if it causes issues.

### Test Builds

Here are some test builds:

* For EOS 600D / Rebel T3i : [magiclantern-eos600d.zip](https://github.com/user-attachments/files/30797215/magiclantern-eos600d.zip)
<!--* For EOS 550D / Rebel T2i : [magiclantern-eos550d.zip](https://github.com/user-attachments/files/30816125/magiclantern-eos550d.zip)-->


### DIGIC 4 lossless core

- Wire `ProcessTwoInTwoOutJpegPath` in `silent/lossless` (split Start, geometry patch, stall-detector completion, LV save/restore, OBWB gain for reduced depths).
- `mlv_lite`: encodable width (`4 mod 8`), overread rows, RAWI level mapping, 6-frame encode warm-up, clean compression-fault stop/drain.

- `raw.c` / `state-object.c`: DIGIC 4 digital-gain fix; Evf EngineError trim so borrowing JPCORE cannot ASSERT the camera.

<img width="720" height="480" alt="VRAM0" src="https://github.com/user-attachments/assets/4055d5c5-c541-4994-a7e3-3d731be68522" />


### Soft preview (separate commit)

- Private low-prio task paints RAW→YUV at ~5 Hz gray / ~2.5 Hz color while recording lossless.
- Skips on real write backlog; OFF restores frozen-LV behaviour.