### PR TITLE
6D2: override the 29:59 MOV/MP4 recording limit

### DIFF
--- a/platform/6D2.111/consts.h
+++ b/platform/6D2.111/consts.h
@@ -131,6 +131,16 @@ extern int winsys_bmp_dirty_bit_neg;
 //#define MVR_LAST_FRAME_SIZE (*(int*)(512 + MVR_752_STRUCT))
 #define MVR_BYTES_WRITTEN MEM((212 + MVR_190_STRUCT))
 
+// Recording time limits, in ms, in a literal pool in ROM0.
+// Both are read by a two-armed getter at 0xe042fee8: the beq at 0xe042fef0
+// selects normal vs high FPS, and each arm is an "ldr r0, [pc, #128]".
+// Located by searching ROM0 for 1799000 (29m59s) and 449000 (7m29s): each byte
+// pattern occurs exactly once in the whole 32MB image, adjacent and in this
+// order, so there is no competing candidate. Verified by decoding both literal
+// loads and confirming their computed targets.
+#define MVR_TIME_LIMIT_NORMAL_FPS 0xe042ff74
+#define MVR_TIME_LIMIT_HIGH_FPS 0xe042ff78
+
 
 // SJE new stuff added after we have ML menus working!
 // Not needed for early code.

--- a/platform/6D2.111/features.h
+++ b/platform/6D2.111/features.h
@@ -36,4 +36,8 @@
 
 #define CONFIG_AUTOBACKUP_ROM
 
+// We are able to override the MOV / MP4 29:59 limit
+// (needs MVR_TIME_LIMIT_NORMAL_FPS / MVR_TIME_LIMIT_HIGH_FPS in consts.h)
+#define FEATURE_OVERRIDE_MOVIE_30_MIN_LIMIT
+
 #undef CONFIG_ADDITIONAL_VERSION


### PR DESCRIPTION
Adds the two `MVR_TIME_LIMIT_*` constants and enables `FEATURE_OVERRIDE_MOVIE_30_MIN_LIMIT` for the 6D2 (1.1.1), following the 200D implementation.

**How the addresses were found:** searched ROM0 for the exact `.old_value` constants `movtweaks.c` asserts against — 1799000 (29m59s) and 449000 (7m29s). Each byte pattern occurs exactly once in the whole 32 MiB image, adjacent and in that order, so there is no competing candidate. Both are reached from a two-armed getter at `0xe042fee8` (the `beq` at `0xe042fef0` selects normal vs high FPS; each arm is an `ldr r0, [pc, #128]` whose computed T1 literal target resolves to these addresses). Verified by decoding the instructions, not by byte pattern-matching alone.

**Tested on a real 6D2 (fw 1.1.1):** limit set to 1 min → recording stops on its own at ~60 s. `apply_patches()` accepted both patches without `E_PATCH_OLD_VALUE_MISMATCH`, independently confirming the `.old_value` constants against this body's ROM. Also double-checked by two consecutive ~448 MB MP4s landing within 0.2% of each other at the 180-min setting test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)