### PR TITLE
property: don't wait out the timeout on writes denied by the whitelist (D678)

### DIFF
--- a/src/property.c
+++ b/src/property.c
@@ -409,6 +409,14 @@ ok:
 
 int prop_request_change_wait(unsigned property, const void* addr, size_t len, int timeout)
 {
+#ifdef CONFIG_DIGIC_678X
+    /* On D678, prop_request_change() silently drops writes to properties not
+     * in prop_write_allow[].  Waiting for an ack from a write that was never
+     * issued just burns the full timeout (2s per gui_uilock() call, from
+     * mlv_lite's polling loop among others).  Bail out up front instead. */
+    if (!is_prop_allowed(property))
+        return 0;
+#endif
     prop_reset_ack(property);
     prop_request_change(property, addr, len);
     


### PR DESCRIPTION
On D678, `prop_request_change()` silently drops writes to properties not in `prop_write_allow[]` — but `prop_request_change_wait()` then polls for an ack that can never arrive, burning the full timeout.

This bites hard in practice: `PROP_ICU_UILOCK` is not whitelisted on any D678 platform, so every `gui_uilock()` call is a silent 2 s stall (up to 4 s for locked→locked transitions), and mlv_lite wraps every buffer realloc in a `gui_uilock()` pair from its polling loop. On a 6D2 this presented as a complete freeze when enabling raw video — console full of `UILock: … => 00000000 (!!!)` — with the camera actually alive underneath, livelocked in timeouts.

Fix: bail out of the wait up front when `is_prop_allowed()` says the write will be dropped. No new property writes are issued; strictly less waiting.

**Tested on a real 6D2 (fw 1.1.1):** with this patch the denied UILock writes complete instantly (the `(!!!)` marker still prints, as before), the raw-video freeze is gone, and mlv_lite went on to record a structurally valid MLV on this body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)