### PR TITLE
log-d678: don't spin forever when the log buffer allocation fails

### DIFF
--- a/src/log-d678.c
+++ b/src/log-d678.c
@@ -313,7 +313,17 @@ void log_start()
 #endif
     qprintf("Logging buffer: %X - %X\n", buf, buf + buf_size - 1);
     qprintf("Free memory: %X\n", GetFreeMemForAllocateMemory());
-    while (!buf);
+    if (!buf)
+    {
+        /* Allocation failed.  This used to be "while (!buf);" - an infinite
+         * spin inside boot_post_init_task with no LED and no display,
+         * indistinguishable from a bricked camera.  Give up on logging
+         * instead: my_DebugMsg() drops everything while buf is NULL, and
+         * log_finish() returns early for the same case, so the camera
+         * boots normally, just without a startup log. */
+        buf_size = 0;
+        return;
+    }
 
     /* override Canon's DebugMsg (requires RAM address) */
     uint32_t old_int = cli();
@@ -359,6 +369,11 @@ void log_start()
 
 void log_finish()
 {
+    /* log_start() bailed out on allocation failure: nothing was patched or
+     * installed, so there is nothing to undo and nothing to save. */
+    if (!buf)
+        return;
+
 #ifdef CONFIG_MMIO_TRACE
     io_trace_uninstall();
     io_trace_dump();

--- a/src/log-d678.c
+++ b/src/log-d678.c
@@ -67,7 +67,7 @@ static void my_DebugMsg(int class, int level, char* fmt, ...)
     const char *task_name = get_current_task_name();
     
     /* Canon's vsnprintf doesn't know %20s */
-    char task_name_padded[11] = "           ";
+    char task_name_padded[12] = "           ";
     int spaces = 10 - strlen(task_name);
     if (spaces < 0)
         spaces = 0;


### PR DESCRIPTION
`log_start()` spins in `while (!buf);` if the initial log-buffer allocation fails. Since this runs from `boot_post_init_task`, an allocation failure presents as an apparently-bricked camera — black screen, no response, nothing to debug with.

The failure is reachable in practice: we hit it on the 6D2 while investigating startup logging (allocation failing at `log_start()` time under certain feature combinations). With this change the logger degrades gracefully — sets `buf_size = 0` and returns, so the camera boots normally, just without a startup log.

Also fixes a gcc 15 build error in the same file (`task_name_padded[11]` has no room for the NUL terminator; `-Werror=unterminated-string-initialization`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)